### PR TITLE
Fix API documentation problems

### DIFF
--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -524,9 +524,13 @@ file against an arbitrary matcher::
 HasLength
 ~~~~~~~~~
 
-Check the length of a collection.  For example::
+Check the length of a collection.  The following assertion will fail::
 
   self.assertThat([1, 2, 3], HasLength(2))
+
+But this one won't::
+
+  self.assertThat([1, 2, 3], HasLength(3))
 
 
 HasPermissions

--- a/testtools/matchers/_higherorder.py
+++ b/testtools/matchers/_higherorder.py
@@ -298,6 +298,7 @@ def MatchesPredicateWithParams(predicate, message, name=None):
 
       HasLength = MatchesPredicate(
           lambda x, y: len(x) == y, 'len({0}) is not {1}')
+      # This assertion will fail, as 'len([1, 2]) == 3' is False.
       self.assertThat([1, 2], HasLength(3))
 
     Note that unlike MatchesPredicate MatchesPredicateWithParams returns a


### PR DESCRIPTION
We were getting failures in our API documentation generation.  Turns out they were due to using _args and *_kwargs in rST strings without code-quoting them.  This patch fixes that.

Since I was there, I thought I'd apply the suggestions given by Vincent in https://code.launchpad.net/~lifeless/testtools/haslength/+merge/144578.
