### PR TITLE
Fix epytext for *args

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -715,7 +715,7 @@ def clone_test_with_new_id(test, new_id):
 def attr(*args):
     """Decorator for adding attributes to WithAttributes.
 
-    :param *args: The name of attributes to add.
+    :param args: The name of attributes to add.
     :return: A callable that when applied to a WithAttributes will
         alter its id to enumerate the added attributes.
     """


### PR DESCRIPTION
http://epydoc.sourceforge.net/fields.html#fields intimates that
'args' is the correct way of spelling '*args'

Broken epytext breaks the daily API doc generation and causes me to get cronspam.
