### PR TITLE
Add filenames to upcall errors

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,9 @@ Improvements
 * ``testtools.compat.unicode_output_stream`` was wrapping a stream encoder
   around ``io.StringIO`` objects, which was incorrect. (Robert Collins)
 
+* Report the name of the source file for setUp and tearDown upcall errors.
+  (Monty Taylor)
+
 0.9.28
 ~~~~~~
 

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -535,10 +535,11 @@ class TestCase(unittest.TestCase):
         ret = self.setUp()
         if not self.__setup_called:
             raise ValueError(
+                "In File: %s\n"
                 "TestCase.setUp was not called. Have you upcalled all the "
                 "way up the hierarchy from your setUp? e.g. Call "
                 "super(%s, self).setUp() from your setUp()."
-                % self.__class__.__name__)
+                % (self.__class__.__file__, self.__class__.__name__))
         return ret
 
     def _run_teardown(self, result):
@@ -551,10 +552,11 @@ class TestCase(unittest.TestCase):
         ret = self.tearDown()
         if not self.__teardown_called:
             raise ValueError(
+                "In File: %s\n"
                 "TestCase.tearDown was not called. Have you upcalled all the "
                 "way up the hierarchy from your tearDown? e.g. Call "
                 "super(%s, self).tearDown() from your tearDown()."
-                % self.__class__.__name__)
+                % (self.__class__.__file__, self.__class__.__name__))
         return ret
 
     def _get_test_method(self):


### PR DESCRIPTION
Match other errors, which report filenames due to having exceptions
associated with them. Since these errors don't stem from exceptions,
it's harder to directly follow where the problem came from.
