### PR TITLE
Fix setUp/tearDown upcall for Python3

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -539,7 +539,8 @@ class TestCase(unittest.TestCase):
                 "TestCase.setUp was not called. Have you upcalled all the "
                 "way up the hierarchy from your setUp? e.g. Call "
                 "super(%s, self).setUp() from your setUp()."
-                % (self.__class__.__file__, self.__class__.__name__))
+                % (sys.modules[self.__class__.__module__].__file__,
+                   self.__class__.__name__))
         return ret
 
     def _run_teardown(self, result):
@@ -556,7 +557,8 @@ class TestCase(unittest.TestCase):
                 "TestCase.tearDown was not called. Have you upcalled all the "
                 "way up the hierarchy from your tearDown? e.g. Call "
                 "super(%s, self).tearDown() from your tearDown()."
-                % (self.__class__.__file__, self.__class__.__name__))
+                % (sys.modules[self.__class__.__module__].__file__,
+                   self.__class__.__name__))
         return ret
 
     def _get_test_method(self):

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1072,6 +1072,9 @@ class TestSetupTearDown(TestCase):
         result = unittest.TestResult()
         DoesnotcallsetUp('test_method').run(result)
         self.assertEqual(1, len(result.errors))
+        self.assertIn(
+            _u("ValueError: In File: testtools/tests/test_testcase.py"),
+            result.errors[0][1])
 
     def test_tearDownNotCalled(self):
         class DoesnotcalltearDown(TestCase):
@@ -1082,6 +1085,9 @@ class TestSetupTearDown(TestCase):
         result = unittest.TestResult()
         DoesnotcalltearDown('test_method').run(result)
         self.assertEqual(1, len(result.errors))
+        self.assertIn(
+            _u("ValueError: In File: testtools/tests/test_testcase.py"),
+            result.errors[0][1])
 
 
 class TestSkipping(TestCase):


### PR DESCRIPTION
Python3 no longer has `__file__` on classes. `__file__` is a property of
modules now. While we're at it, add a test to ensure that the appropriate
error string winds up in the test output.
