### PR TITLE
Fix the no-upcall error on Python3.4 https://bugs.launchpad.net/testtools/+bug/1140688

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -539,7 +539,8 @@ class TestCase(unittest.TestCase):
                 "TestCase.setUp was not called. Have you upcalled all the "
                 "way up the hierarchy from your setUp? e.g. Call "
                 "super(%s, self).setUp() from your setUp()."
-                % (self.__class__.__file__, self.__class__.__name__))
+                % (sys.modules[self.__class__.__module__].__file__,
+                   self.__class__.__name__))
         return ret
 
     def _run_teardown(self, result):
@@ -556,7 +557,8 @@ class TestCase(unittest.TestCase):
                 "TestCase.tearDown was not called. Have you upcalled all the "
                 "way up the hierarchy from your tearDown? e.g. Call "
                 "super(%s, self).tearDown() from your tearDown()."
-                % (self.__class__.__file__, self.__class__.__name__))
+                % (sys.modules[self.__class__.__module__].__file__,
+                   self.__class__.__name__))
         return ret
 
     def _get_test_method(self):

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -31,6 +31,7 @@ from testtools.matchers import (
     Annotate,
     DocTestMatches,
     Equals,
+    HasLength,
     MatchesException,
     Raises,
     )
@@ -1071,7 +1072,11 @@ class TestSetupTearDown(TestCase):
                 pass
         result = unittest.TestResult()
         DoesnotcallsetUp('test_method').run(result)
-        self.assertEqual(1, len(result.errors))
+        self.assertThat(result.errors, HasLength(1))
+        self.assertThat(result.errors[0][1],
+            DocTestMatches(
+                "...ValueError...File...testtools/tests/test_testcase.py...",
+                ELLIPSIS))
 
     def test_tearDownNotCalled(self):
         class DoesnotcalltearDown(TestCase):
@@ -1081,7 +1086,11 @@ class TestSetupTearDown(TestCase):
                 pass
         result = unittest.TestResult()
         DoesnotcalltearDown('test_method').run(result)
-        self.assertEqual(1, len(result.errors))
+        self.assertThat(result.errors, HasLength(1))
+        self.assertThat(result.errors[0][1],
+            DocTestMatches(
+                "...ValueError...File...testtools/tests/test_testcase.py...",
+                ELLIPSIS))
 
 
 class TestSkipping(TestCase):


### PR DESCRIPTION
Fixed version of Monty's patch.
