### PR TITLE
Adds a CopyStreamResult which copies StreamResult events to multiple outputs.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,10 @@ Improvements
 * New class ``StreamResult`` which defines the API for the new result type.
   (Robert Collins)
 
+* New support class ``CopyStreamResult`` which forwards events onto multiple
+  ``StreamResult`` objects (each of which receives all the events).
+  (Robert Collins)
+
 * New ``TestCase`` decorator ``DecorateTestCaseResult`` that adapts the
   ``TestResult`` or ``StreamResult`` a case will be run with, for ensuring that
   a particular result object is used even if the runner running the test doesn't

--- a/testtools/__init__.py
+++ b/testtools/__init__.py
@@ -4,6 +4,7 @@
 
 __all__ = [
     'clone_test_with_new_id',
+    'CopyStreamResult',
     'ConcurrentTestSuite',
     'DecorateTestCaseResult',
     'ErrorHolder',
@@ -67,6 +68,7 @@ else:
         skipUnless,
         )
     from testtools.testresult import (
+        CopyStreamResult,
         ExtendedToOriginalDecorator,
         MultiTestResult,
         StreamResult,

--- a/testtools/testresult/__init__.py
+++ b/testtools/testresult/__init__.py
@@ -3,6 +3,7 @@
 """Test result objects."""
 
 __all__ = [
+    'CopyStreamResult',
     'ExtendedToOriginalDecorator',
     'MultiTestResult',
     'StreamResult',
@@ -15,6 +16,7 @@ __all__ = [
     ]
 
 from testtools.testresult.real import (
+    CopyStreamResult,
     ExtendedToOriginalDecorator,
     MultiTestResult,
     StreamResult,

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -14,6 +14,7 @@ __all__ = [
     ]
 
 import datetime
+from operator import methodcaller
 import sys
 import unittest
 
@@ -360,6 +361,35 @@ class StreamResult(object):
             defaults to application/octet-stream. Ignores unless file_name
             has been supplied.
         """
+
+
+def domap(*args, **kwargs):
+    return list(map(*args, **kwargs))
+
+
+class CopyStreamResult(StreamResult):
+    """Copies all event it receives to multiple results.
+    
+    This provides an easy facility for combining multiple StreamResults.
+
+    For TestResult the equivalent class was ``MultiTestResult``.
+    """
+
+    def __init__(self, targets):
+        super(CopyStreamResult, self).__init__()
+        self.targets = targets
+
+    def startTestRun(self):
+        super(CopyStreamResult, self).startTestRun()
+        domap(methodcaller('startTestRun'), self.targets)
+
+    def stopTestRun(self):
+        super(CopyStreamResult, self).stopTestRun()
+        domap(methodcaller('stopTestRun'), self.targets)
+
+    def status(self, *args, **kwargs):
+        super(CopyStreamResult, self).status(*args, **kwargs)
+        domap(methodcaller('status', *args, **kwargs), self.targets)
 
 
 class MultiTestResult(TestResult):

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -19,6 +19,7 @@ import warnings
 from extras import safe_hasattr
 
 from testtools import (
+    CopyStreamResult,
     ExtendedToOriginalDecorator,
     MultiTestResult,
     PlaceHolder,
@@ -49,6 +50,7 @@ from testtools.content import (
     )
 from testtools.content_type import ContentType, UTF8_TEXT
 from testtools.matchers import (
+    AllMatch,
     Contains,
     DocTestMatches,
     Equals,
@@ -511,6 +513,12 @@ class TestBaseStreamResultContract(TestCase, TestStreamResultContract):
         return StreamResult()
 
 
+class TestCopyStreamResultContract(TestCase, TestStreamResultContract):
+
+    def _make_result(self):
+        return CopyStreamResult([StreamResult(), StreamResult()])
+
+
 class TestDoubleStreamResultContract(TestCase, TestStreamResultContract):
 
     def _make_result(self):
@@ -551,6 +559,38 @@ class TestDoubleStreamResultEvents(TestCase):
             [('startTestRun',),
              ('status', 'foo', 'success', set(['tag']), False, None, None, False, None, 'abc', now)],
             result._events)
+
+
+class TestCopyStreamResultCopies(TestCase):
+
+    def setUp(self):
+        super(TestCopyStreamResultCopies, self).setUp()
+        self.target1 = LoggingStreamResult()
+        self.target2 = LoggingStreamResult()
+        self.targets = [self.target1._events, self.target2._events]
+        self.result = CopyStreamResult([self.target1, self.target2])
+
+    def test_startTestRun(self):
+        self.result.startTestRun()
+        self.assertThat(self.targets, AllMatch(Equals([('startTestRun',)])))
+
+    def test_stopTestRun(self):
+        self.result.startTestRun()
+        self.result.stopTestRun()
+        self.assertThat(self.targets,
+            AllMatch(Equals([('startTestRun',), ('stopTestRun',)])))
+
+    def test_status(self):
+        self.result.startTestRun()
+        now = datetime.datetime.now(utc)
+        self.result.status("foo", "success", test_tags=set(['tag']),
+            runnable=False, file_name="foo", file_bytes=b'bar', eof=True,
+            mime_type="text/json", route_code='abc', timestamp=now)
+        self.assertThat(self.targets,
+            AllMatch(Equals([('startTestRun',),
+                ('status', 'foo', 'success', set(['tag']), False, "foo",
+                 b'bar', True, "text/json", 'abc', now)
+                ])))
 
 
 class TestTestResult(TestCase):


### PR DESCRIPTION
This allows applying multiple terminal handlers to one stream.
