### PR TITLE
Add an adapter to convert ExtendedTestResult to StreamResult.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -41,6 +41,16 @@ Improvements
 * New support class ``StreamFailFast`` which calls a ``TestControl`` instance
   to abort the test run when a failure is detected. (Robert Collins)
 
+* New support class ``ExtendedToStreamDecorator`` which translates both regular
+  unittest TestResult API calls and the ExtendedTestResult API which testtools
+  has supported into the StreamResult API. ExtendedToStreamDecorator also
+  forwards calls made in the StreamResult API, permitting it to be used
+  anywhere a StreamResult is used. Key TestResult query methods like
+  wasSuccessful and shouldStop are synchronised with the StreamResult API
+  calls, but the detailed statistics like the list of errors are not - a
+  separate consumer will be created to support that.
+  (Robert Collins)
+
 * New ``TestCase`` decorator ``DecorateTestCaseResult`` that adapts the
   ``TestResult`` or ``StreamResult`` a case will be run with, for ensuring that
   a particular result object is used even if the runner running the test doesn't

--- a/doc/for-framework-folk.rst
+++ b/doc/for-framework-folk.rst
@@ -204,6 +204,15 @@ with the result. e.g.::
     >>> # At stopTestRun() any incomplete buffered tests are announced.
     >>> result.stopTestRun()
 
+ExtendedToStreamDecorator
+-------------------------
+
+This is a hybrid object that combines both the ``Extended`` and ``Stream``
+``TestResult`` APIs into one class, but only emits ``StreamResult`` events.
+This is useful when a ``StreamResult`` stream is desired, but you cannot
+be sure that the tests which will run have been updated to the ``StreamResult``
+API.
+
 ThreadsafeStreamResult
 ----------------------
 

--- a/testtools/__init__.py
+++ b/testtools/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     'ErrorHolder',
     'ExpectedException',
     'ExtendedToOriginalDecorator',
+    'ExtendedToStreamDecorator',
     'FixtureSuite',
     'iterate_tests',
     'MultipleExceptions',
@@ -74,6 +75,7 @@ else:
     from testtools.testresult import (
         CopyStreamResult,
         ExtendedToOriginalDecorator,
+        ExtendedToStreamDecorator,
         MultiTestResult,
         StreamFailFast,
         StreamResult,

--- a/testtools/testresult/__init__.py
+++ b/testtools/testresult/__init__.py
@@ -5,6 +5,7 @@
 __all__ = [
     'CopyStreamResult',
     'ExtendedToOriginalDecorator',
+    'ExtendedToStreamDecorator',
     'MultiTestResult',
     'StreamFailFast',
     'StreamResult',
@@ -22,6 +23,7 @@ __all__ = [
 from testtools.testresult.real import (
     CopyStreamResult,
     ExtendedToOriginalDecorator,
+    ExtendedToStreamDecorator,
     MultiTestResult,
     StreamFailFast,
     StreamResult,

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -21,6 +21,7 @@ from extras import safe_hasattr
 from testtools import (
     CopyStreamResult,
     ExtendedToOriginalDecorator,
+    ExtendedToStreamDecorator,
     MultiTestResult,
     PlaceHolder,
     StreamFailFast,
@@ -232,18 +233,21 @@ class TagsContract(Python27Contract):
     def test_no_tags_by_default(self):
         # Results initially have no tags.
         result = self.makeResult()
+        result.startTestRun()
         self.assertEqual(frozenset(), result.current_tags)
 
     def test_adding_tags(self):
         # Tags are added using 'tags' and thus become visible in
         # 'current_tags'.
         result = self.makeResult()
+        result.startTestRun()
         result.tags(set(['foo']), set())
         self.assertEqual(set(['foo']), result.current_tags)
 
     def test_removing_tags(self):
         # Tags are removed using 'tags'.
         result = self.makeResult()
+        result.startTestRun()
         result.tags(set(['foo']), set())
         result.tags(set(), set(['foo']))
         self.assertEqual(set(), result.current_tags)
@@ -251,6 +255,7 @@ class TagsContract(Python27Contract):
     def test_startTestRun_resets_tags(self):
         # startTestRun makes a new test run, and thus clears all the tags.
         result = self.makeResult()
+        result.startTestRun()
         result.tags(set(['foo']), set())
         result.startTestRun()
         self.assertEqual(set(), result.current_tags)
@@ -448,6 +453,12 @@ class TestAdaptedPython27TestResultContract(TestCase, DetailsContract):
         return ExtendedToOriginalDecorator(Python27TestResult())
 
 
+class TestAdaptedStreamResult(TestCase, DetailsContract):
+
+    def makeResult(self):
+        return ExtendedToStreamDecorator(StreamResult())
+
+
 class TestTestResultDecoratorContract(TestCase, StartTestRunContract):
 
     run_test_with = FullStackRunTest
@@ -528,6 +539,12 @@ class TestDoubleStreamResultContract(TestCase, TestStreamResultContract):
 
     def _make_result(self):
         return LoggingStreamResult()
+
+
+class TestExtendedToStreamDecoratorContract(TestCase, TestStreamResultContract):
+
+    def _make_result(self):
+        return ExtendedToStreamDecorator(StreamResult())
 
 
 class TestStreamSummaryResultContract(TestCase, TestStreamResultContract):
@@ -701,6 +718,53 @@ class TestStreamToDict(TestCase):
         self.assertEqual(["A", "B"], tests[0]['timestamps'])
         self.assertEqual(["C", None], tests[1]['timestamps'])
 
+
+class TestExtendedToStreamDecorator(TestCase):
+
+    def test_explicit_time(self):
+        log = LoggingStreamResult()
+        result = ExtendedToStreamDecorator(log)
+        result.startTestRun()
+        now = datetime.datetime.now(utc)
+        result.time(now)
+        result.startTest(self)
+        result.addSuccess(self)
+        result.stopTest(self)
+        result.stopTestRun()
+        self.assertEqual([
+            ('startTestRun',),
+            ('status',
+             'testtools.tests.test_testresult.TestExtendedToStreamDecorator.test_explicit_time',
+             'inprogress',
+             None,
+             True,
+             None,
+             None,
+             False,
+             None,
+             None,
+             now),
+            ('status',
+             'testtools.tests.test_testresult.TestExtendedToStreamDecorator.test_explicit_time',
+             'success',
+              set(),
+              True,
+              None,
+              None,
+              False,
+              None,
+              None,
+              now),
+             ('stopTestRun',)], log._events)
+
+    def test_wasSuccessful_after_stopTestRun(self):
+        log = LoggingStreamResult()
+        result = ExtendedToStreamDecorator(log)
+        result.startTestRun()
+        result.status(test_id='foo', test_status='fail')
+        result.stopTestRun()
+        self.assertEqual(False, result.wasSuccessful())
+        
 
 class TestStreamFailFast(TestCase):
 


### PR DESCRIPTION
This permits using code that uses any Python unittest test code
with a StreamResult.
