### PR TITLE
Add a timestamping StreamResult.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -62,6 +62,9 @@ Improvements
   ``TestResult``) calls. This permits using un-migrated result objects with
   new runners / tests. (Robert Collins)
 
+* New support class ``TimestampingStreamResult`` which adds a timestamp to
+  events with no timestamp. (Robert Collins)
+
 * New ``TestCase`` decorator ``DecorateTestCaseResult`` that adapts the
   ``TestResult`` or ``StreamResult`` a case will be run with, for ensuring that
   a particular result object is used even if the runner running the test doesn't

--- a/doc/for-framework-folk.rst
+++ b/doc/for-framework-folk.rst
@@ -241,6 +241,15 @@ at once. Each method takes out a lock around the decorated result to prevent
 race conditions. The ``startTestRun`` and ``stopTestRun`` methods are not
 forwarded to prevent the decorated result having them called multiple times.
 
+TimestampingStreamResult
+------------------------
+
+This is a ``StreamResult`` decorator for adding timestamps to events that lack
+them. This allows writing the simplest possible generators of events and
+passing the events via this decorator to get timestamped data. As long as
+no buffering/queueing or blocking happen before the timestamper sees the event
+the timestamp will be as accurate as if the original event had it.
+
 TestResult.addSkip
 ------------------
 

--- a/testtools/__init__.py
+++ b/testtools/__init__.py
@@ -36,6 +36,7 @@ __all__ = [
     'StreamToExtendedDecorator',
     'TestControl',
     'ThreadsafeForwardingResult',
+    'TimestampingStreamResult',
     'try_import',
     'try_imports',
     ]
@@ -92,6 +93,7 @@ else:
         TestResultDecorator,
         TextTestResult,
         ThreadsafeForwardingResult,
+        TimestampingStreamResult,
         )
     from testtools.testsuite import (
         ConcurrentTestSuite,

--- a/testtools/testresult/__init__.py
+++ b/testtools/testresult/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     'TestResultDecorator',
     'TextTestResult',
     'ThreadsafeForwardingResult',
+    'TimestampingStreamResult',
     ]
 
 from testtools.testresult.real import (
@@ -40,4 +41,5 @@ from testtools.testresult.real import (
     TestResultDecorator,
     TextTestResult,
     ThreadsafeForwardingResult,
+    TimestampingStreamResult,
     )

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -18,6 +18,7 @@ __all__ = [
     'TestResult',
     'TestResultDecorator',
     'ThreadsafeForwardingResult',
+    'TimestampingStreamResult',
     ]
 
 import datetime
@@ -1486,6 +1487,23 @@ class TestByTestResult(TestResult):
         super(TestByTestResult, self).addUnexpectedSuccess(test, details)
         self._status = 'success'
         self._details = details
+
+
+class TimestampingStreamResult(CopyStreamResult):
+    """A StreamResult decorator that assigns a timestamp when none is present.
+
+    This is convenient for ensuring events are timestamped.
+    """
+
+    def __init__(self, target):
+        super(TimestampingStreamResult, self).__init__([target])
+
+    def status(self, *args, **kwargs):
+        timestamp = kwargs.pop('timestamp', None)
+        if timestamp is None:
+            timestamp = datetime.datetime.now(utc)
+        super(TimestampingStreamResult, self).status(
+            *args, timestamp=timestamp, **kwargs)
 
 
 class _StringException(Exception):


### PR DESCRIPTION
This allows event generators to ignore the timestamp field, it can be added
into the stream - as long as it is before any buffering/queueing/blocking occur
it will be accurate enough.
