### PR TITLE
Fix assertRaises when the exception has a metaclass

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -17,6 +17,7 @@ The testtools authors are:
  * Gavin Panella
  * Martin Pool
  * Vincent Ladeuil
+ * Nikola Đipanov
 
 and are collectively referred to as "testtools developers".
 

--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,8 @@ experimental and we might need to break it.
 
 Improvements
 ------------
+* ``assertRaises`` works properly for exception classes that have custom 
+  metaclasses
 
 * ``ConcurrentTestSuite`` was silently eating exceptions that propagate from
   the test.run(result) method call. Ignoring them is fine in a normal test

--- a/testtools/matchers/_exception.py
+++ b/testtools/matchers/_exception.py
@@ -44,7 +44,9 @@ class MatchesException(Matcher):
         if istext(value_re):
             value_re = AfterPreproccessing(str, MatchesRegex(value_re), False)
         self.value_re = value_re
-        self._is_instance = type(self.expected) not in classtypes() + (tuple,)
+        expected_type = type(self.expected)
+        self._is_instance = not any(issubclass(expected_type, class_type) 
+                for class_type in classtypes() + (tuple,))
 
     def match(self, other):
         if type(other) != tuple:

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -302,6 +302,19 @@ class TestAssertions(TestCase):
         # assertRaises asserts that a callable raises a particular exception.
         self.assertRaises(RuntimeError, self.raiseError, RuntimeError)
 
+    def test_assertRaises_exception_w_metaclass(self):
+        # assertRaises works when called for exceptions with custom metaclasses
+        class MyExMeta(type):
+            def __init__(cls, name, bases, dct):
+                """ Do some dummy metaclass stuff """
+                dct.update({'answer': 42})
+                type.__init__(cls, name, bases, dct)
+
+        class MyEx(Exception):
+            __metaclass__ = MyExMeta
+
+        self.assertRaises(MyEx, self.raiseError, MyEx)
+
     def test_assertRaises_fails_when_no_error_raised(self):
         # assertRaises raises self.failureException when it's passed a
         # callable that raises no error.


### PR DESCRIPTION
Due to not taking into account that the type of the class can be a
subclass of type (which is the case when using metaclasses),
assertRaises would report a false positive in case an exception that was
expected had a custom metaclass.

This patch introduces a more robust checking if a given object is a
class or an instance of one, and adds a test case, to make sure
exceptions with custom metaclasses don't break assertRaises.
