### PR TITLE
Implements assertNotIsInstance

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -372,6 +372,13 @@ class TestCase(unittest.TestCase):
             matcher = IsInstance(klass)
         self.assertThat(obj, matcher, msg)
 
+    def assertNotIsInstance(self, obj, klass, msg=None):
+        if isinstance(klass, tuple):
+            matcher = Not(IsInstance(*klass))
+        else:
+            matcher = Not(IsInstance(klass))
+        self.assertThat(obj, matcher, msg)
+
     def assertRaises(self, excClass, callableObj, *args, **kwargs):
         """Fail unless an exception of class excClass is thrown
            by callableObj when invoked with arguments args and keyword

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -468,6 +468,54 @@ class TestAssertions(TestCase):
         self.assertFails("'42' is not an instance of str: foo",
             self.assertIsInstance, 42, str, "foo")
 
+    def test_assertNotIsInstance(self):
+        # assertNotIsInstance asserts that an object is
+        # not an instance of a class.
+
+        class Foo(object):
+            """Simple class for testing assertIsInstance."""
+
+        foo = Foo()
+        self.assertNotIsInstance(foo, str)
+
+    def test_assertNotIsInstance_multiple_classes(self):
+        # assertNotIsInstance asserts that an object is
+        # not an instance of any of a group of classes.
+
+        class Foo(object):
+            """Simple class for testing assertIsInstance."""
+
+        class Bar(object):
+            """Another simple class for testing assertIsInstance."""
+
+        foo = Foo()
+        self.assertNotIsInstance(foo, (str, dict))
+        self.assertNotIsInstance(Bar(), (str, dict))
+
+    def test_assertNotIsInstance_failure(self):
+        # assertNotIsInstance(obj, klass) fails the test when obj is an
+        # instance of klass.
+
+        self.assertFails(
+            "'42' matches IsInstance(%s)" % self._formatTypes(str),
+            self.assertNotIsInstance, '42', str)
+
+    def test_assertNotIsInstance_failure_multiple_classes(self):
+        # assertNotIsInstance(obj, (klass1, klass2)) fails the test when obj is
+        # an instance of klass1 or klass2.
+
+        self.assertFails(
+            "'42' matches IsInstance(%s)" % self._formatTypes([str, int]),
+            self.assertNotIsInstance, '42', (str, int))
+        self.assertFails(
+            "42 matches IsInstance(%s)" % self._formatTypes([str, int]),
+            self.assertNotIsInstance, 42, (str, int))
+
+    def test_assertIsInstance_overridden_message(self):
+        # assertIsInstance(obj, klass, msg) permits a custom message.
+        self.assertFails("'42' matches IsInstance(str): foo",
+            self.assertNotIsInstance, '42', str, "foo")
+
     def test_assertIs(self):
         # assertIs asserts that an object is identical to another object.
         self.assertIs(None, None)


### PR DESCRIPTION
The method 'assertNotIsInstance' was introduced in python 2.7 but was not
able to call through testtools in python 2.6.
http://docs.python.org/2/library/unittest.html#unittest.TestCase.assertNotIs

This patch implements the 'assertNotIsInstance' testcase.
