### PR TITLE
Replace list.sort() with sorted()

### DIFF
--- a/testtools/testsuite.py
+++ b/testtools/testsuite.py
@@ -304,5 +304,5 @@ def filter_by_ids(suite_or_case, test_ids):
 def sorted_tests(suite_or_case, unpack_outer=False):
     """Sort suite_or_case while preserving non-vanilla TestSuites."""
     tests = _flatten_tests(suite_or_case, unpack_outer=unpack_outer)
-    tests.sort()
+    tests = sorted(tests, key=lambda x: x[0])
     return unittest.TestSuite([test for (sort_key, test) in tests])


### PR DESCRIPTION
In OpenStack heatclient project, there is error running in py33 env:
https://bugs.launchpad.net/python-heatclient/+bug/1243096

For the Python 2&3 compatability, use sorted() builtin to replace
list.sort().

This change is verified in OpenStack heatclient/novaclient projects.
(tox -e py27 / tox -e py33)
