### PR TITLE
Add StackLinesContent, reimplement TracebackContent to use this new class

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,8 @@ Improvements
   (Thomi Richards)
 * Removed some unused code from ``testtools.content.TracebackContent``.
   (Thomi Richards)
+* Added ``testtools.StackLinesContent``: a content object for displaying
+  pre-processed stack lines. (Thomi Richards)
 
 0.9.32
 ~~~~~~

--- a/testtools/tests/helpers.py
+++ b/testtools/tests/helpers.py
@@ -11,7 +11,7 @@ import sys
 from extras import safe_hasattr
 
 from testtools import TestResult
-from testtools.content import TracebackContent
+from testtools.content import StackLinesContent
 from testtools import runtest
 
 
@@ -83,12 +83,12 @@ class LoggingResult(TestResult):
 
 
 def is_stack_hidden():
-    return TracebackContent.HIDE_INTERNAL_STACK
+    return StackLinesContent.HIDE_INTERNAL_STACK
 
 
 def hide_testtools_stack(should_hide=True):
-    result = TracebackContent.HIDE_INTERNAL_STACK
-    TracebackContent.HIDE_INTERNAL_STACK = should_hide
+    result = StackLinesContent.HIDE_INTERNAL_STACK
+    StackLinesContent.HIDE_INTERNAL_STACK = should_hide
     return result
 
 

--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -19,6 +19,7 @@ from testtools.content import (
     content_from_stream,
     JSON,
     json_content,
+    StackLinesContent,
     TracebackContent,
     text_content,
     )
@@ -192,6 +193,49 @@ class TestContent(TestCase):
         data = {'foo': 'bar'}
         expected = Content(JSON, lambda: [_b('{"foo": "bar"}')])
         self.assertEqual(expected, json_content(data))
+
+
+class TestStackLinesContent(TestCase):
+
+    def _get_stack_line_and_expected_output(self):
+        stack_lines = [
+            ('/path/to/file', 42, 'some_function', 'print("Hello World")'),
+        ]
+        expected = '  File "/path/to/file", line 42, in some_function\n' \
+                   '    print("Hello World")\n'
+        return stack_lines, expected
+
+    def test_single_stack_line(self):
+        stack_lines, expected = self._get_stack_line_and_expected_output()
+        actual = StackLinesContent(stack_lines).as_text()
+
+        self.assertEqual(expected, actual)
+
+    def test_prefix_content(self):
+        stack_lines, expected = self._get_stack_line_and_expected_output()
+        prefix = self.getUniqueString() + '\n'
+        content = StackLinesContent(stack_lines, prefix_content=prefix)
+        actual = content.as_text()
+        expected = prefix  + expected
+
+        self.assertEqual(expected, actual)
+
+    def test_postfix_content(self):
+        stack_lines, expected = self._get_stack_line_and_expected_output()
+        postfix = '\n' + self.getUniqueString()
+        content = StackLinesContent(stack_lines, postfix_content=postfix)
+        actual = content.as_text()
+        expected = expected + postfix
+
+        self.assertEqual(expected, actual)
+
+    def test___init___sets_content_type(self):
+        stack_lines, expected = self._get_stack_line_and_expected_output()
+        content = StackLinesContent(stack_lines)
+        expected_content_type = ContentType("text", "x-traceback",
+            {"language": "python", "charset": "utf8"})
+
+        self.assertEqual(expected_content_type, content.content_type)
 
 
 class TestTracebackContent(TestCase):


### PR DESCRIPTION
Add a new content class: testtools.content.StackLinesContent that takes a list of pre-processed stack lines, and produces a content object. Refactor TracebackContent class to be a function that returns an instance of StackLinesContent.

This is a precursor to adding non-fatal exceptions, since we need a way to add stack line content objects without having an exception.
