### PR TITLE
Fix StreamSummary counting of testsRun.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,10 @@ Improvements
 * Added ``testtools.StackLinesContent``: a content object for displaying
   pre-processed stack lines. (Thomi Richards)
 
+* ``StreamSummary`` was calculating testsRun incorrectly: ``exists`` status
+  tests were counted as run tests, but they are not.
+  (Robert Collins, #1203728)
+
 0.9.32
 ~~~~~~
 

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -737,9 +737,9 @@ class StreamSummary(StreamToDict):
         return (not self.failures and not self.errors)
 
     def _gather_test(self, test_dict):
-        self.testsRun += 1
         if test_dict['status'] == 'exists':
             return
+        self.testsRun += 1
         case = test_dict_to_case(test_dict)
         self._handle_status[test_dict['status']](case)
 

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -947,7 +947,8 @@ class TestStreamSummary(TestCase):
         result.status("baz", "exists")
         result.stopTestRun()
         self.assertEqual(True, result.wasSuccessful())
-        self.assertEqual(3, result.testsRun)
+        # Existence is terminal but doesn't count as 'running' a test.
+        self.assertEqual(2, result.testsRun)
 
     def test_stopTestRun_inprogress_test_fails(self):
         # Tests inprogress at stopTestRun trigger a failure.


### PR DESCRIPTION
StreamSummary was calculating testsRun incorrectly: exists status tests were
counted as run tests, but they are not.

Change-Id: I9581be45e878a4281904e2039dd7790f9bc1a3bb
Closes-Bug: #1203728
