### PR TITLE
In Python 3.3, if there are duplicate test ids, tests.sort()

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,11 @@ Improvements
   exiting (2) when an import has failed rather than only signalling through the
   test name. (Robert Collins, #1245672)
 
+* In Python 3.3, if there are duplicate test ids, tests.sort() will
+  fail and raise TypeError. Detect the duplicate test ids firstly in
+  sorted_tests() to ensure that all test ids are unique.
+  (Kui Shi, #1243922)
+
 0.9.33
 ~~~~~~
 

--- a/doc/for-framework-folk.rst
+++ b/doc/for-framework-folk.rst
@@ -411,6 +411,10 @@ if it is a good idea).
 sorted_tests
 ------------
 
+In Python 3.3, if there are duplicate test ids, tests.sort() will fail and
+raise TypeError. Detect the duplicate test ids firstly in sorted_tests()
+to ensure that all test ids are unique.
+
 Given the composite structure of TestSuite / TestCase, sorting tests is
 problematic - you can't tell what functionality is embedded into custom Suite
 implementations. In order to deliver consistent test orders when using test

--- a/testtools/tests/test_testsuite.py
+++ b/testtools/tests/test_testsuite.py
@@ -224,6 +224,19 @@ class TestFixtureSuite(TestCase):
         suite.run(LoggingResult([]))
         self.assertEqual(['setUp', 1, 2, 'tearDown'], log)
 
+    def test_fixture_suite_sort(self):
+        log = []
+        class Sample(TestCase):
+            def test_one(self):
+                log.append(1)
+            def test_two(self):
+                log.append(2)
+        fixture = FunctionFixture(
+            lambda: log.append('setUp'),
+            lambda fixture: log.append('tearDown'))
+        suite = FixtureSuite(fixture, [Sample('test_one'), Sample('test_one')])
+        self.assertRaises(ValueError, suite.sort_tests)
+
 
 class TestSortedTests(TestCase):
 
@@ -252,6 +265,13 @@ class TestSortedTests(TestCase):
         b = PlaceHolder('b')
         suite = sorted_tests(unittest.TestSuite([b, a]))
         self.assertEqual([a, b], list(iterate_tests(suite)))
+
+    def test_duplicate_simple_suites(self):
+        a = PlaceHolder('a')
+        b = PlaceHolder('b')
+        c = PlaceHolder('a')
+        self.assertRaises(ValueError,
+                          sorted_tests, unittest.TestSuite([a, b, c]))
 
 
 def test_suite():

--- a/testtools/testsuite.py
+++ b/testtools/testsuite.py
@@ -303,6 +303,18 @@ def filter_by_ids(suite_or_case, test_ids):
 
 def sorted_tests(suite_or_case, unpack_outer=False):
     """Sort suite_or_case while preserving non-vanilla TestSuites."""
+
+    # Duplicate test id can induce TypeError in Python 3.3.
+    # Detect the duplicate test id, raise exception when found.
+    seen = set()
+    for test_case in iterate_tests(suite_or_case):
+        test_id = test_case.id()
+        if test_id not in seen:
+            seen.add(test_id)
+        else:
+            raise ValueError('Duplicate test id detected: %s' % (test_id,))
+
     tests = _flatten_tests(suite_or_case, unpack_outer=unpack_outer)
     tests.sort()
+
     return unittest.TestSuite([test for (sort_key, test) in tests])


### PR DESCRIPTION
will fail and raise TypeError.

Detect the duplicate test ids firstly in sorted_tests() to ensure
that all test ids are unique.
