### PR TITLE
Add testtools.StacktraceContent.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -23,6 +23,10 @@ Improvements
   exiting (2) when an import has failed rather than only signalling through the
   test name. (Robert Collins, #1245672)
 
+* Added ``testtools.content.StacktraceContent``, a content object that
+  automatically creates a ``StackLinesContent`` object containing the current
+  stack trace. (Thomi Richards)
+
 0.9.33
 ~~~~~~
 

--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -20,6 +20,7 @@ from testtools.content import (
     JSON,
     json_content,
     StackLinesContent,
+    StacktraceContent,
     TracebackContent,
     text_content,
     )
@@ -252,6 +253,33 @@ class TestTracebackContent(TestCase):
         result = unittest.TestResult()
         expected = result._exc_info_to_string(an_exc_info, self)
         self.assertEqual(expected, ''.join(list(content.iter_text())))
+
+
+class TestStacktraceContent(TestCase):
+
+    def test___init___sets_ivars(self):
+        content = StacktraceContent()
+        content_type = ContentType("text", "x-traceback",
+            {"language": "python", "charset": "utf8"})
+
+        self.assertEqual(content_type, content.content_type)
+
+    def test_prefix_is_used(self):
+        prefix = self.getUniqueString()
+        actual = StacktraceContent(prefix_content=prefix).as_text()
+
+        self.assertTrue(actual.startswith(prefix))
+
+    def test_postfix_is_used(self):
+        postfix = self.getUniqueString()
+        actual = StacktraceContent(postfix_content=postfix).as_text()
+
+        self.assertTrue(actual.endswith(postfix))
+
+    def test_top_frame_is_skipped_when_no_stack_is_specified(self):
+        actual = StacktraceContent().as_text()
+
+        self.assertTrue('testtools/content.py' not in actual)
 
 
 class TestAttachFile(TestCase):


### PR DESCRIPTION
This PR creates the StacktraceContent class. It simply creates a StackLinesContent object based on the current frame stack (the other function that uses StackLinesContent is TracebackContent, which does a similar thing, but for an exception traceback).

The use case is for the delayed assertion code, where we want to add a stack trace as a detail of a test every time a delayed assertion happens, so the user can see on which lines something went wrong.

I'm looking for some feedback on this one. In particular I'd like some input on how to test this. Creating a fake stack trace is a lot harder in this case, since creating mock frame objects is a real pain (and in any way I can't really see whjy you'd ever want to pass in a stack object...).

I've tested the things I can think of with automated tests, and tested the rest manually, but I'd love to improve that situation.
