### PR TITLE
Add assertRaisesRegexp method.

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -39,6 +39,7 @@ from testtools.matchers import (
     Equals,
     MatchesAll,
     MatchesException,
+    MatchesRegex,
     MismatchError,
     Is,
     IsInstance,
@@ -393,6 +394,16 @@ class TestCase(unittest.TestCase):
         self.assertThat(our_callable, matcher)
         return capture.matchee
     failUnlessRaises = assertRaises
+
+    def assertRaisesRegexp(self, excClass, pattern, callableObj, *args,
+                           **kwargs):
+        """Fail unless an exception of class excClass is thrown
+           by callableObj when invoked with arguments args and keyword
+           arguments kwargs and exception message matches pattern.
+        """
+        exception = self.assertRaises(excClass, callableObj, *args, **kwargs)
+        matcher = MatchesRegex(pattern)
+        self.assertThat(exception.args[0], matcher)
 
     def assertThat(self, matchee, matcher, message='', verbose=False):
         """Assert that matchee is matched by matcher.

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -34,6 +34,7 @@ from testtools.matchers import (
     Equals,
     HasLength,
     MatchesException,
+    MismatchError,
     Raises,
     )
 from testtools.testcase import (
@@ -379,6 +380,24 @@ class TestAssertions(TestCase):
             lambda: self.assertRaises(Exception, foo),
             Raises(
                 MatchesException(self.failureException, '.*%r.*' % (foo,))))
+
+    def test_assertRaisesRegexp(self):
+        # assertRaisesRegexp asserts that function raises particular exception
+        # with particular message.
+        self.assertRaisesRegexp(RuntimeError, "M\w*e", self.raiseError,
+                                RuntimeError, "Message")
+
+    def test_assertRaisesRegexp_wrong_error_type(self):
+        # If function raises an exception of unexpected type,
+        # assertRaisesRegexp re-raise it.
+        self.assertRaises(SyntaxError, self.assertRaisesRegexp, RuntimeError,
+                          "M\w*e", self.raiseError, SyntaxError, "Message")
+
+    def test_assertRaisesRegexp_wrong_message(self):
+        # If function raises an exception with unexpected message
+        # assertRaisesregexp raise MismatchError.
+        self.assertRaises(MismatchError, self.assertRaisesRegexp, RuntimeError,
+                          "Msg", self.raiseError, RuntimeError, "Message")
 
     def assertFails(self, message, function, *args, **kwargs):
         """Assert that function raises a failure with the given message."""


### PR DESCRIPTION
The method assertRaisesRegexp was introduced in python 2.7.
This patch implements assertRaisesReagexp method to make possible
using it in python 2.6.

assertRaisesRegexp asserts that a method raises an exception
and given pattern matches on the string representation of the raised
exception.