### PR TITLE
Added verbose error information

### DIFF
--- a/testtools/run.py
+++ b/testtools/run.py
@@ -54,7 +54,15 @@ def list_test(test):
     for test in iterate_tests(test):
         # to this ugly.
         if test.id().startswith(unittest_import_str):
-            errors.append(test.id()[len(unittest_import_str):])
+            failure = getattr(test, test._testMethodName)
+            try:
+                failure()
+            except Exception as e:
+                error_exception = e
+            error_message = 'test id - %s\nfailure reason - %s' % (
+                test.id()[len(unittest_import_str):],
+                str(error_exception))
+            errors.append(error_message)
         else:
             test_ids.append(test.id())
     return test_ids, errors

--- a/testtools/tests/test_run.py
+++ b/testtools/tests/test_run.py
@@ -146,9 +146,7 @@ testtools.runexample.TestFoo.test_quux
             SystemExit,
             run.main, ['prog', 'discover', '-l', broken.package.base, '*.py'], out)
         self.assertEqual(2, exc.args[0])
-        self.assertEqual("""Failed to import
-runexample.__init__
-""", out.getvalue())
+        self.assertRegexMatches(out.getvalue(), ".*Failed to import.*runexample.__init__.*")
 
     def test_run_orders_tests(self):
         self.useFixture(SampleTestFixture())


### PR DESCRIPTION
Added verbose error message about why test cannot be loaded.

Partial-Fix for https://bugs.launchpad.net/testrepository/+bug/1271133

To fix this bug we need to add changes to 3 projects:
testrepository - https://code.launchpad.net/~alexei-kornienko/testrepository/bug-1271133
testtools - https://github.com/testing-cabal/testtools/pull/77
subunit - https://code.launchpad.net/~alexei-kornienko/subunit/bug-1271133


