### PR TITLE
Fix expected failure

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,12 @@ Changes and improvements to testtools_, grouped by release.
 NEXT
 ~~~~
 
+Changes
+-------
+
+* Make testtools compatible with the ``unittest.expectedFailure`` decorator in
+  Python 3.4. (Thomi Richards)
+
 0.9.35
 ~~~~~~
 

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -984,6 +984,28 @@ class TestExpectedFailure(TestWithDetails):
         self.assertDetailsProvided(case, "addUnexpectedSuccess",
             ["foo", "reason"])
 
+    @skipIf(not hasattr(unittest, 'expectedFailure'), 'Need py27+')
+    def test_unittest_expectedFailure_decorator_works_with_failure(self):
+        class ReferenceTest(TestCase):
+            @unittest.expectedFailure
+            def test_fails_expectedly(self):
+                self.assertEquals(1, 0)
+
+        test = ReferenceTest('test_fails_expectedly')
+        result = test.run()
+        self.assertEqual(True, result.wasSuccessful())
+
+    @skipIf(not hasattr(unittest, 'expectedFailure'), 'Need py27+')
+    def test_unittest_expectedFailure_decorator_works_with_success(self):
+        class ReferenceTest(TestCase):
+            @unittest.expectedFailure
+            def test_passes_unexpectedly(self):
+                self.assertEquals(1, 1)
+
+        test = ReferenceTest('test_passes_unexpectedly')
+        result = test.run()
+        self.assertEqual(False, result.wasSuccessful())
+
 
 class TestUniqueFactories(TestCase):
     """Tests for getUniqueString and getUniqueInteger."""


### PR DESCRIPTION
Python 3.4's unittest module introduces the concept of subtests. As part of this change, the 'expectedFailure' decorator was changed. 

Before python 3.4, it looked like this:

```
def expectedFailure(func):
    @functools.wraps(func)
    def wrapper(*args, **kwargs):
        try:
            func(*args, **kwargs)
        except Exception:
            raise _ExpectedFailure(sys.exc_info())
        raise _UnexpectedSuccess
    return wrapper
```

After python 3.4, it looks like this:

```
def expectedFailure(test_item):
    test_item.__unittest_expecting_failure__ = True
    return test_item
```

This breaks tests that use testtools.TestCase and unittest.expectedFailure together.

This pull request detects the new-style expectedDecorator on a test, and silently wraps it in the old decorator, thereby maintaining compatibility.
