### PR TITLE
Raise a TypeError when text_content is passed bytes, so we get an error as early as possible.

### DIFF
--- a/testtools/content.py
+++ b/testtools/content.py
@@ -25,6 +25,7 @@ from testtools.compat import (
     _b,
     _format_exception_only,
     _format_stack_list,
+    _isbytes,
     _TB_HEADER,
     _u,
     str_is_unicode,
@@ -263,6 +264,8 @@ def text_content(text):
 
     This is useful for adding details which are short strings.
     """
+    if _isbytes(text):
+        raise TypeError('text_content must be given a string, not bytes.')
     return Content(UTF8_TEXT, lambda: [text.encode('utf8')])
 
 

--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -5,12 +5,13 @@ import os
 import tempfile
 import unittest
 
-from testtools import TestCase
+from testtools import TestCase, skipUnless
 from testtools.compat import (
     _b,
     _u,
     BytesIO,
     StringIO,
+    str_is_unicode,
     )
 from testtools.content import (
     attach_file,
@@ -189,6 +190,11 @@ class TestContent(TestCase):
         data = _u("some data")
         expected = Content(UTF8_TEXT, lambda: [data.encode('utf8')])
         self.assertEqual(expected, text_content(data))
+
+    @skipUnless(str_is_unicode, "Test only applies in python 3.")
+    def test_text_content_raises_TypeError_when_passed_bytes(self):
+        data = _b("Some Bytes")
+        self.assertRaises(TypeError, text_content, data)
 
     def test_json_content(self):
         data = {'foo': 'bar'}


### PR DESCRIPTION
Content objects are lazy, which is fine, except that in some cases this can made debugging much harder. One particular case I come across often is that text_content has been called with a bytes object, rather than a str object. The stack trace we get tells us what went wrong, but does not tell us where or when the content object was created, which is what we want to know in order to fix the issue.

This PR adds a simple check in python 3 to make sure that we're being passed a text object, not a bytestring.
