### PR TITLE
Raise an error if text_content is passed something other than text.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,12 @@ Changes and improvements to testtools_, grouped by release.
 NEXT
 ~~~~
 
+Changes
+-------
+
+* Made ``testtools.content.text_content`` raise a ``TypeError`` if passed
+  something other than text. (Thomi Richards)
+
 0.9.35
 ~~~~~~
 

--- a/testtools/content.py
+++ b/testtools/content.py
@@ -27,6 +27,7 @@ from testtools.compat import (
     _format_stack_list,
     _TB_HEADER,
     _u,
+    istext,
     str_is_unicode,
 )
 from testtools.content_type import ContentType, JSON, UTF8_TEXT
@@ -263,6 +264,8 @@ def text_content(text):
 
     This is useful for adding details which are short strings.
     """
+    if not istext(text):
+        raise TypeError("'text' parameter must be a string, not %s" % type(text).__name__)
     return Content(UTF8_TEXT, lambda: [text.encode('utf8')])
 
 

--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -2,10 +2,14 @@
 
 import json
 import os
+import sys
 import tempfile
 import unittest
 
-from testtools import TestCase
+from testtools import (
+    TestCase,
+    skipIf,
+    )
 from testtools.compat import (
     _b,
     _u,
@@ -189,6 +193,14 @@ class TestContent(TestCase):
         data = _u("some data")
         expected = Content(UTF8_TEXT, lambda: [data.encode('utf8')])
         self.assertEqual(expected, text_content(data))
+
+    @skipIf(sys.version < '3', "Only applicable in python 3.")
+    def test_text_content_raises_TypeError_when_not_given_text(self):
+        fn = lambda: text_content(_b('Some Bytes'))
+        self.assertThat(
+            fn,
+            raises(TypeError("'text' parameter must be a string, not bytes"))
+        )
 
     def test_json_content(self):
         data = {'foo': 'bar'}


### PR DESCRIPTION
We frequently find tracebacks that look like this:

```
  File "/home/thomi/code/canonical/autopilot/video-rmd-refactoring1/autopilot/testresult.py", line 57, in _log_details
    text = "%s: {{{\n%s}}}" % (detail, detail_content.as_text())
  File "/usr/lib/python3/dist-packages/testtools/content.py", line 93, in as_text
    return _u('').join(self.iter_text())
  File "/usr/lib/python3/dist-packages/testtools/content.py", line 116, in _iter_text
    for bytes in self.iter_bytes():
  File "/usr/lib/python3/dist-packages/testtools/content.py", line 97, in iter_bytes
    return self._get_bytes()
  File "/usr/lib/python3/dist-packages/testtools/content.py", line 266, in <lambda>
    return Content(UTF8_TEXT, lambda: [text.encode('utf8')])
AttributeError: 'bytes' object has no attribute 'encode'
```

Here, a test author has tried to add a content object using 'text_content', but has mistakenly passed a bytes object instead. The traceback doesn't tell us where the text_content call was made though, and doesn't give any other clues to aid debugging.

This branch aims to solve that by making text_content check the type of the 'text' parameter, and raise a TypeError if it's not the appropriate type. While it won't eliminate these issues, it should address the most common cause (for our application anyway).
