### PR TITLE
Revert back to explicit test identification.

### DIFF
--- a/.testr.conf
+++ b/.testr.conf
@@ -1,4 +1,4 @@
 [DEFAULT]
-test_command=${PYTHON:-python} -m subunit.run discover . $LISTOPT $IDOPTION
+test_command=${PYTHON:-python} -m subunit.run $LISTOPT $IDOPTION testtools.tests.test_suite
 test_id_option=--load-list $IDFILE
 test_list_option=--list


### PR DESCRIPTION
We haven't setup load_test hooks, and trunk doesn't actually work with
discover :(.

Change-Id: Id7d1a48251c4f9e4147815f9effc2239645869d5
