### PR TITLE
Handle content objects better

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,13 @@ Changes and improvements to testtools_, grouped by release.
 NEXT
 ~~~~
 
+Changes
+-------
+
+* The ``ExtendedToStreamDecorator`` now handles content objects with one less
+  packet - the last packet of the source content is sent with EOF set rather
+  than an empty packet with EOF set being sent after the last packet of the
+  source content. (Robert Collins)
 
 0.9.36
 ~~~~~~

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -1336,10 +1336,13 @@ class ExtendedToStreamDecorator(CopyStreamResult, StreamSummary, TestControl):
         if details is not None:
             for name, content in details.items():
                 mime_type = repr(content.content_type)
-                for file_bytes in content.iter_bytes():
-                    self.status(file_name=name, file_bytes=file_bytes,
-                        mime_type=mime_type, test_id=test_id, timestamp=now)
-                self.status(file_name=name, file_bytes=_b(""), eof=True,
+                file_bytes = None
+                for next_bytes in content.iter_bytes():
+                    if file_bytes is not None:
+                        self.status(file_name=name, file_bytes=file_bytes,
+                            mime_type=mime_type, test_id=test_id, timestamp=now)
+                    file_bytes = next_bytes
+                self.status(file_name=name, file_bytes=file_bytes, eof=True,
                     mime_type=mime_type, test_id=test_id, timestamp=now)
         if reason is not None:
             self.status(file_name='reason', file_bytes=reason.encode('utf8'),

--- a/testtools/tests/test_testsuite.py
+++ b/testtools/tests/test_testsuite.py
@@ -189,12 +189,10 @@ TypeError: run() takes ...1 ...argument...2...given...
         self.assertEqual([
             ('status', "broken-runner-'0'", 'inprogress', None, True, None, None, False, None, _u('0'), None),
             ('status', "broken-runner-'0'", None, None, True, 'traceback', None,
-             False,
+             True,
              'text/x-traceback; charset="utf8"; language="python"',
              '0',
              None),
-             ('status', "broken-runner-'0'", None, None, True, 'traceback', b'', True,
-              'text/x-traceback; charset="utf8"; language="python"', '0', None),
              ('status', "broken-runner-'0'", 'fail', set(), True, None, None, False, None, _u('0'), None)
             ], events)
 


### PR DESCRIPTION
The `ExtendedToStreamDecorator` now handles content objects with one
less packet - the last packet of the content has EOF set rather than
an empty packet with EOF set being sent.

Change-Id: If908c1fe8e6fbe2ac3834a1cd99e7cd8ace45b3b
