### PR TITLE
Fix broken links to old mumak.net documentation

### DIFF
--- a/doc/for-framework-folk.rst
+++ b/doc/for-framework-folk.rst
@@ -14,8 +14,8 @@ unit-tested project, are trying to get one testing framework to play nicely
 with another or are hacking away at getting your test suite to run in parallel
 over a heterogenous cluster of machines, this guide is for you.
 
-This manual is a summary.  You can get details by consulting the `testtools
-API docs`_.
+This manual is a summary. You can get details by consulting the
+:doc:`testtools API docs </api>`.
 
 
 Extensions to TestCase
@@ -449,6 +449,5 @@ To facilitate custom listing of tests, ``testtools.run.TestProgram`` attempts
 to call ``list`` on the ``TestRunner``, falling back to a generic
 implementation if it is not present.
 
-.. _`testtools API docs`: http://mumak.net/testtools/apidocs/
 .. _unittest: http://docs.python.org/library/unittest.html
 .. _fixture: http://pypi.python.org/pypi/fixtures

--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -11,7 +11,7 @@ automated testing already.
 If you are a test author of an unusually large or unusually unusual test
 suite, you might be interested in :doc:`for-framework-folk`.
 
-You might also be interested in the `testtools API docs`_.
+You might also be interested in the :doc:`testtools API docs </api>`.
 
 
 Introduction
@@ -1480,7 +1480,6 @@ Here, ``repr(nullary)`` will be the same as ``repr(f)``.
 .. _doctest: http://docs.python.org/library/doctest.html
 .. _Deferred: http://twistedmatrix.com/documents/current/core/howto/defer.html
 .. _discover: http://pypi.python.org/pypi/discover
-.. _`testtools API docs`: http://mumak.net/testtools/apidocs/
 .. _Distutils: http://docs.python.org/library/distutils.html
 .. _`setup configuration`: http://docs.python.org/distutils/configfile.html
 .. _broken: http://chipaca.com/post/3210673069/hasattr-17-less-harmful


### PR DESCRIPTION
No more links to mumak.net. Ought to fix #81.
