### PR TITLE
Fix issue where using the skip* family of decorators still ran the setUp and tearDown test methods.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,10 @@ NEXT
 Improvements
 ------------
 
+* Fix an issue where tests skipped with the ``skip``* family of decorators would
+  still have their ``setUp`` and ``tearDown`` functions called.
+  (Thomi Richards, #https://github.com/testing-cabal/testtools/issues/86)
+
 * We have adopted a formal backwards compatibility statement (see hacking.rst)
   (Robert Collins)
 

--- a/testtools/runtest.py
+++ b/testtools/runtest.py
@@ -112,6 +112,14 @@ class RunTest(object):
 
     def _run_core(self):
         """Run the user supplied test code."""
+        test_method = self.case._get_test_method()
+        if getattr(test_method, '__unittest_skip__', False):
+            self.result.addSkip(
+                self.case,
+                reason=getattr(test_method, '__unittest_skip_why__', None)
+            )
+            return
+
         if self.exception_caught == self._run_user(self.case._run_setup,
             self.result):
             # Don't run the test method if we failed getting here.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -841,6 +841,12 @@ def skip(reason):
     @unittest.skip decorator.
     """
     def decorator(test_item):
+        # This attribute signals to RunTest._run_core that the entire test
+        # must be skipped - including setUp and tearDown. This makes us
+        # compatible with testtools.skip* functions, which set the same
+        # attributes.
+        test_item.__unittest_skip__ = True
+        test_item.__unittest_skip_why__ = reason
         if wraps is not None:
             @wraps(test_item)
             def skip_wrapper(*args, **kwargs):

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1260,6 +1260,12 @@ class TestSetupTearDown(TestCase):
                 ELLIPSIS))
 
 
+require_py27_minimum = skipIf(
+    sys.version < '2.7',
+    "Requires python 2.7 or greater"
+)
+
+
 class TestSkipping(TestCase):
     """Tests for skipping of tests functionality."""
 
@@ -1362,6 +1368,71 @@ class TestSkipping(TestCase):
         test = SkippingTest("test_that_is_decorated_with_skipUnless")
         test.run(result)
         self.assertEqual('addSuccess', result._events[1][0])
+
+    def check_skip_decorator_does_not_run_setup(self, decorator, reason):
+        class SkippingTest(TestCase):
+
+            setup_ran = False
+
+            def setUp(self):
+                super(SkippingTest, self).setUp()
+                self.setup_ran = True
+
+            # Use the decorator passed to us:
+            @decorator
+            def test_skipped(self):
+                self.fail()
+
+        test = SkippingTest('test_skipped')
+        result = test.run()
+        self.assertTrue(result.wasSuccessful())
+        self.assertTrue(reason in result.skip_reasons, result.skip_reasons)
+        self.assertFalse(test.setup_ran)
+
+    def test_testtools_skip_decorator_does_not_run_setUp(self):
+        reason = self.getUniqueString()
+        self.check_skip_decorator_does_not_run_setup(
+            skip(reason),
+            reason
+        )
+
+    def test_testtools_skipIf_decorator_does_not_run_setUp(self):
+        reason = self.getUniqueString()
+        self.check_skip_decorator_does_not_run_setup(
+            skipIf(True, reason),
+            reason
+        )
+
+    def test_testtools_skipUnless_decorator_does_not_run_setUp(self):
+        reason = self.getUniqueString()
+        self.check_skip_decorator_does_not_run_setup(
+            skipUnless(False, reason),
+            reason
+        )
+
+    @require_py27_minimum
+    def test_unittest_skip_decorator_does_not_run_setUp(self):
+        reason = self.getUniqueString()
+        self.check_skip_decorator_does_not_run_setup(
+            unittest.skip(reason),
+            reason
+        )
+
+    @require_py27_minimum
+    def test_unittest_skipIf_decorator_does_not_run_setUp(self):
+        reason = self.getUniqueString()
+        self.check_skip_decorator_does_not_run_setup(
+            unittest.skipIf(True, reason),
+            reason
+        )
+
+    @require_py27_minimum
+    def test_unittest_skipUnless_decorator_does_not_run_setUp(self):
+        reason = self.getUniqueString()
+        self.check_skip_decorator_does_not_run_setup(
+            unittest.skipUnless(False, reason),
+            reason
+        )
 
 
 class TestOnException(TestCase):


### PR DESCRIPTION
This closes #86.

I make the testtools skip decorator set the **unittest_skip** attribute on test methods, which makes them compatible with the unittest functions of the same name. 

I then change RunTest._run_core to look for that attribute and not run setUp if it's present. 
