### PR TITLE
Fix handling of uncatchable exceptions.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,18 @@ NEXT
 Improvements
 ------------
 
+* Fix a long-standing bug where tearDown and cleanUps would not be called if the
+  test run was interrupted. This should fix leaking external resources from
+  interrupted tests.
+  (Robert Collins, #1364188)
+
+* Fix a long-standing bug where calling sys.exit(0) from within a test would
+  cause the test suite to exit with 0, without reporting a failure of that
+  test. We still allow the test suite to be exited (since catching higher order
+  exceptions requires exceptional circumstances) but we now call a last-resort
+  handler on the TestCase, resulting in an error being reported for the test.
+  (Robert Collins, #1364188)
+
 * Fix an issue where tests skipped with the ``skip``* family of decorators would
   still have their ``setUp`` and ``tearDown`` functions called.
   (Thomi Richards, #https://github.com/testing-cabal/testtools/issues/86)

--- a/doc/for-framework-folk.rst
+++ b/doc/for-framework-folk.rst
@@ -50,9 +50,9 @@ provide a custom ``RunTest`` to a ``TestCase``.  The ``RunTest`` object can
 change everything about how the test executes.
 
 To work with ``testtools.TestCase``, a ``RunTest`` must have a factory that
-takes a test and an optional list of exception handlers.  Instances returned
-by the factory must have a ``run()`` method that takes an optional ``TestResult``
-object.
+takes a test and an optional list of exception handlers and an optional
+last_resort handler.  Instances returned by the factory must have a ``run()``
+method that takes an optional ``TestResult`` object.
 
 The default is ``testtools.runtest.RunTest``, which calls ``setUp``, the test
 method, ``tearDown`` and clean ups (see :ref:`addCleanup`) in the normal, vanilla

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -89,14 +89,21 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
     This is highly experimental code.  Use at your own risk.
     """
 
-    def __init__(self, case, handlers=None, reactor=None, timeout=0.005,
-                 debug=False):
+    def __init__(self, case, handlers=None, last_resort=None, reactor=None,
+                 timeout=0.005, debug=False):
         """Construct an `AsynchronousDeferredRunTest`.
+
+        Please be sure to always use keyword syntax, not positional, as the
+        base class may add arguments in future - and for core code
+        compatibility with that we have to insert them before the local
+        parameters.
 
         :param case: The `TestCase` to run.
         :param handlers: A list of exception handlers (ExceptionType, handler)
             where 'handler' is a callable that takes a `TestCase`, a
             ``testtools.TestResult`` and the exception raised.
+        :param last_resort: Handler to call before re-raising uncatchable
+            exceptions (those for which there is no handler).
         :param reactor: The Twisted reactor to use.  If not given, we use the
             default reactor.
         :param timeout: The maximum time allowed for running a test.  The
@@ -105,7 +112,8 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
             to get information about unhandled Deferreds and left-over
             DelayedCalls.  Defaults to False.
         """
-        super(AsynchronousDeferredRunTest, self).__init__(case, handlers)
+        super(AsynchronousDeferredRunTest, self).__init__(
+            case, handlers, last_resort)
         if reactor is None:
             from twisted.internet import reactor
         self._reactor = reactor
@@ -119,8 +127,8 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
         # will be able to be assigned to a class variable *and* also be
         # invoked directly.
         class AsynchronousDeferredRunTestFactory:
-            def __call__(self, case, handlers=None):
-                return cls(case, handlers, reactor, timeout, debug)
+            def __call__(self, case, handlers=None, last_resort=None):
+                return cls(case, handlers, last_resort, reactor, timeout, debug)
         return AsynchronousDeferredRunTestFactory()
 
     @defer.deferredGenerator

--- a/testtools/tests/test_deferredruntest.py
+++ b/testtools/tests/test_deferredruntest.py
@@ -53,6 +53,12 @@ class X(object):
             self.calls.append('tearDown')
             super(X.Base, self).tearDown()
 
+    class BaseExceptionRaised(Base):
+        expected_calls = ['setUp', 'tearDown', 'clean-up']
+        expected_results = [('addError', SystemExit)]
+        def test_something(self):
+            raise SystemExit(0)
+
     class ErrorInSetup(Base):
         expected_calls = ['setUp', 'clean-up']
         expected_results = [('addError', RuntimeError)]
@@ -103,7 +109,10 @@ class X(object):
         def test_runner(self):
             result = ExtendedTestResult()
             test = self.test_factory('test_something', runTest=self.runner)
-            test.run(result)
+            if self.test_factory is X.BaseExceptionRaised:
+                self.assertRaises(SystemExit, test.run, result)
+            else:
+                test.run(result)
             self.assertEqual(test.calls, self.test_factory.expected_calls)
             self.assertResultsMatch(test, result)
 
@@ -118,6 +127,7 @@ def make_integration_tests():
         ]
 
     tests = [
+        X.BaseExceptionRaised,
         X.ErrorInSetup,
         X.ErrorInTest,
         X.ErrorInTearDown,

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -909,6 +909,18 @@ class TestAddCleanup(TestCase):
             set(self.logging_result._events[1][2].keys()))
 
 
+class TestRunTestUsage(TestCase):
+
+    def test_last_resort_in_place(self):
+        class TestBase(TestCase):
+            def test_base_exception(self):
+                raise SystemExit(0)
+        result = ExtendedTestResult()
+        test = TestBase("test_base_exception")
+        self.assertRaises(SystemExit, test.run, result)
+        self.assertFalse(result.wasSuccessful())
+
+
 class TestWithDetails(TestCase):
 
     run_test_with = FullStackRunTest


### PR DESCRIPTION
Fix a long-standing bug where tearDown and cleanUps would not be
called if the test run was interrupted. This should fix leaking
external resources from interrupted tests.
(Robert Collins, #1364188)

Fix a long-standing bug where calling sys.exit(0) from within a test
would cause the test suite to exit with 0, without reporting a failure
of that test. We still allow the test suite to be exited (since
catching higher order exceptions requires exceptional circumstances)
but we now call a last-resort handler on the TestCase, resulting in an
error being reported for the test.
(Robert Collins, #1364188)

Change-Id: I0700f33fe7ed01416b37c21eb3f3fd0a7ea917eb
