### PR TITLE
Fix masking of fixture.setUp errors.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,13 @@ Changes and improvements to testtools_, grouped by release.
 NEXT
 ~~~~
 
+Improvements
+------------
+
+* Exceptions in a ``fixture.getDetails`` method will no longer mask errors
+  raised from the same fixture's ``setUp`` method.
+  (Robert Collins, #1368440)
+
 1.0.0
 ~~~~~
 

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -661,8 +661,18 @@ class TestCase(unittest.TestCase):
         try:
             fixture.setUp()
         except:
-            gather_details(fixture.getDetails(), self.getDetails())
-            raise
+            exc_info = sys.exc_info()
+            try:
+                gather_details(fixture.getDetails(), self.getDetails())
+            except:
+                # Report the setUp exception, then raise the error during
+                # gather_details.
+                self._report_traceback(exc_info)
+                raise
+            else:
+                # Gather_details worked, so raise the exception setUp
+                # encountered.
+                reraise(*exc_info)
         else:
             self.addCleanup(fixture.cleanUp)
             self.addCleanup(


### PR DESCRIPTION
Exceptions in a `fixture.getDetails` method will no longer mask
errors raised from the same fixture's `setUp` method.
(Robert Collins, #1368440)

Change-Id: I39da334ba57683fd71a5d7af16c32d9170f6e626
