### PR TITLE
Make text_content more explicit about the types that it accepts.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -13,6 +13,9 @@ Changes
 * Fixed unit tests which were failing under pypy due to a change in the way
   pypy formats tracebacks. (Thomi Richards)
 
+* Make `testtools.content.text_content` error if anything other than text
+  is given as content. (Thomi Richards)
+
 1.1.0
 ~~~~~
 

--- a/testtools/content.py
+++ b/testtools/content.py
@@ -25,9 +25,9 @@ from testtools.compat import (
     _b,
     _format_exception_only,
     _format_stack_list,
-    _isbytes,
     _TB_HEADER,
     _u,
+    istext,
     str_is_unicode,
 )
 from testtools.content_type import ContentType, JSON, UTF8_TEXT
@@ -264,8 +264,10 @@ def text_content(text):
 
     This is useful for adding details which are short strings.
     """
-    if _isbytes(text):
-        raise TypeError('text_content must be given a string, not bytes.')
+    if not istext(text):
+        raise TypeError(
+            "text_content must be given text, not '%s'." % type(text).__name__
+        )
     return Content(UTF8_TEXT, lambda: [text.encode('utf8')])
 
 

--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -196,6 +196,17 @@ class TestContent(TestCase):
         data = _b("Some Bytes")
         self.assertRaises(TypeError, text_content, data)
 
+    def test_text_content_raises_TypeError_when_passed_non_text(self):
+        bad_values = (None, list(), dict(), 42, 1.23)
+        for value in bad_values:
+            self.assertThat(
+                lambda: text_content(value),
+                raises(
+                    TypeError("text_content must be given text, not '%s'." %
+                        type(value).__name__)
+                ),
+            )
+
     def test_json_content(self):
         data = {'foo': 'bar'}
         expected = Content(JSON, lambda: [_b('{"foo": "bar"}')])


### PR DESCRIPTION
I've had a crack at this previously - I added a check for when text_content is passed bytes instead of text. I'm still seeing ambiguous errors due to people creating content objects with the wrong type. I'd like to plug the problem in text_content, which is the most used entry point from autopilot.
