### PR TITLE
Make tests pass on pypy

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,12 @@ Changes and improvements to testtools_, grouped by release.
 NEXT
 ~~~~
 
+Changes
+-------
+
+* Fixed unit tests which were failing under pypy due to a change in the way
+  pypy formats tracebacks. (Thomi Richards)
+
 1.1.0
 ~~~~~
 


### PR DESCRIPTION
It seems that pypy have changed the way they print tracebacks. This PR changes sopme unit tests to be more flexible about whitespace in traceback strings.
