### PR TITLE
Fix setUpClass upcalls on Python 2.6.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,13 @@ Changes and improvements to testtools_, grouped by release.
 NEXT
 ~~~~
 
+Changes
+-------
+
+* ``testtools.TestCase`` now inherits from unittest2.TestCase, which
+  provides a ``setUpClass`` for upcalls on Python 2.6.
+  (Robert Collins, #1393283)
+
 1.3.0
 ~~~~~
 

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -20,12 +20,12 @@ import functools
 import itertools
 import sys
 import types
-import unittest
 
 from extras import (
     safe_hasattr,
     try_import,
     )
+import unittest2 as unittest
 
 from testtools import (
     content,

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1602,40 +1602,43 @@ class TestNullary(TestCase):
         self.assertRaises(ZeroDivisionError, wrapped)
 
 
+class Attributes(WithAttributes, TestCase):
+    @attr('foo')
+    def simple(self):
+        pass
+
+    # Not sorted here, forward or backwards.
+    @attr('foo', 'quux', 'bar')
+    def many(self):
+        pass
+
+    # Not sorted here, forward or backwards.
+    @attr('bar')
+    @attr('quux')
+    @attr('foo')
+    def decorated(self):
+        pass
+
+
 class TestAttributes(TestCase):
 
     def test_simple_attr(self):
         # Adding an attr to a test changes its id().
-        class MyTest(WithAttributes, TestCase):
-            @attr('foo')
-            def test_bar(self):
-                pass
-        case = MyTest('test_bar')
-        self.assertEqual('testtools.tests.test_testcase.MyTest.test_bar[foo]',
+        case = Attributes('simple')
+        self.assertEqual(
+            'testtools.tests.test_testcase.Attributes.simple[foo]',
             case.id())
 
     def test_multiple_attributes(self):
-        class MyTest(WithAttributes, TestCase):
-            # Not sorted here, forward or backwards.
-            @attr('foo', 'quux', 'bar')
-            def test_bar(self):
-                pass
-        case = MyTest('test_bar')
+        case = Attributes('many')
         self.assertEqual(
-            'testtools.tests.test_testcase.MyTest.test_bar[bar,foo,quux]',
+            'testtools.tests.test_testcase.Attributes.many[bar,foo,quux]',
             case.id())
 
     def test_multiple_attr_decorators(self):
-        class MyTest(WithAttributes, TestCase):
-            # Not sorted here, forward or backwards.
-            @attr('bar')
-            @attr('quux')
-            @attr('foo')
-            def test_bar(self):
-                pass
-        case = MyTest('test_bar')
+        case = Attributes('decorated')
         self.assertEqual(
-            'testtools.tests.test_testcase.MyTest.test_bar[bar,foo,quux]',
+            'testtools.tests.test_testcase.Attributes.decorated[bar,foo,quux]',
             case.id())
 
 

--- a/testtools/tests/test_testsuite.py
+++ b/testtools/tests/test_testsuite.py
@@ -218,6 +218,25 @@ TypeError: run() takes ...1 ...argument...2...given...
         suite.run(result)
         self.assertEqual(['addSkip'], [item[0] for item in log])
 
+    def test_setupclass_upcall(self):
+        # Note that this is kindof-a-case-test, kindof-suite, because
+        # setUpClass is linked between them.
+        class Simples(TestCase):
+            @classmethod
+            def setUpClass(cls):
+                super(Simples, cls).setUpClass()
+            def test_simple(self):
+                pass
+        # Test discovery uses the default suite from unittest2 (unless users
+        # deliberately change things, in which case they keep both pieces).
+        suite = unittest2.TestSuite([Simples("test_simple")])
+        log = []
+        result = LoggingResult(log)
+        suite.run(result)
+        self.assertEqual(
+            ['startTest', 'addSuccess', 'stopTest'],
+            [item[0] for item in log])
+
 
 class TestFixtureSuite(TestCase):
 


### PR DESCRIPTION
`testtools.TestCase` now inherits from unittest2.TestCase, which
provides a `setUpClass` for upcalls on Python 2.6.
(Robert Collins, #1393283)

Change-Id: Id56212e3d7d519c7b73d2e19d3e34013fac34544
