### PR TITLE
Collect all duplicate test id's before raise

### DIFF
--- a/testtools/testsuite.py
+++ b/testtools/testsuite.py
@@ -305,14 +305,20 @@ def filter_by_ids(suite_or_case, test_ids):
 def sorted_tests(suite_or_case, unpack_outer=False):
     """Sort suite_or_case while preserving non-vanilla TestSuites."""
     # Duplicate test id can induce TypeError in Python 3.3.
-    # Detect the duplicate test id, raise exception when found.
-    seen = set()
+    # Detect the duplicate test id's, raise exception when found.
+    seen = dict()
     for test_case in iterate_tests(suite_or_case):
         test_id = test_case.id()
-        if test_id not in seen:
-            seen.add(test_id)
+        if test_id not in seen.keys():
+            seen[test_id] = 1
         else:
-            raise ValueError('Duplicate test id detected: %s' % (test_id,))
+            seen[test_id] += 1
+
+    duplicates = dict((test_id, seen[test_id])
+                      for test_id, count in seen.items() if count > 1)
+    if duplicates:
+        raise ValueError('Duplicate test id\'s detected: %s' % (duplicates,))
+
     tests = _flatten_tests(suite_or_case, unpack_outer=unpack_outer)
     tests.sort()
     return unittest.TestSuite([test for (sort_key, test) in tests])


### PR DESCRIPTION
To simplify debugging duplicate test id's, collect all duplicates,
remember the number of duplicates and raise an Exception after all
duplicates are found.

Closes-Bug: #1390082