### PR TITLE
Fix output of empty attachments.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,14 @@ Changes and improvements to testtools_, grouped by release.
 NEXT
 ~~~~
 
+Improvements
+------------
+
+* Empty attachments to tests were triggering a file payload of None in the
+  ``ExtendedToStreamDecorator`` code, which caused multiple copies of
+  attachments that had been output prior to the empty one.
+  (Robert Collins, #1378609)
+
 1.6.1
 ~~~~~
 

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -1346,6 +1346,8 @@ class ExtendedToStreamDecorator(CopyStreamResult, StreamSummary, TestControl):
                         self.status(file_name=name, file_bytes=file_bytes,
                             mime_type=mime_type, test_id=test_id, timestamp=now)
                     file_bytes = next_bytes
+                if file_bytes is None:
+                    file_bytes = _b("")
                 self.status(file_name=name, file_bytes=file_bytes, eof=True,
                     mime_type=mime_type, test_id=test_id, timestamp=now)
         if reason is not None:

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -848,6 +848,53 @@ class TestExtendedToStreamDecorator(TestCase):
         result.stopTestRun()
         self.assertEqual(False, result.wasSuccessful())
 
+    def test_empty_detail_status_correct(self):
+        log = LoggingStreamResult()
+        result = ExtendedToStreamDecorator(log)
+        result.startTestRun()
+        now = datetime.datetime.now(utc)
+        result.time(now)
+        result.startTest(self)
+        result.addError(self, details={'foo': text_content(_u(""))})
+        result.stopTest(self)
+        result.stopTestRun()
+        self.assertEqual([
+            ('startTestRun',),
+            ('status',
+             'testtools.tests.test_testresult.TestExtendedToStreamDecorator.test_empty_detail_status_correct',
+             'inprogress',
+             None,
+             True,
+             None,
+             None,
+             False,
+             None,
+             None,
+             now),
+            ('status',
+             'testtools.tests.test_testresult.TestExtendedToStreamDecorator.test_empty_detail_status_correct',
+              None,
+              None,
+              True,
+              'foo',
+              _b(''),
+              True,
+              'text/plain; charset="utf8"',
+              None,
+              now),
+            ('status',
+             'testtools.tests.test_testresult.TestExtendedToStreamDecorator.test_empty_detail_status_correct',
+             'fail',
+              set(),
+              True,
+              None,
+              None,
+              False,
+              None,
+              None,
+              now),
+             ('stopTestRun',)], log._events)
+
 
 class TestStreamFailFast(TestCase):
 


### PR DESCRIPTION
Empty attachments to tests were triggering a file payload of None in the
``ExtendedToStreamDecorator`` code, which caused multiple copies of
attachments that had been output prior to the empty one.
(Robert Collins, #1378609)

Change-Id: I34a989546d57b245d4384b8c5b6d444e7ce0ac1b