### PR TITLE
Fix building universal wheels on Python 3.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -7,6 +7,13 @@ Changes and improvements to testtools_, grouped by release.
 NEXT
 ~~~~
 
+Improvements
+------------
+
+* Building a wheel on Python 3 was missing ``_compat2x.py`` needed for Python2.
+  This was a side effect of the fix to bug #941958, where we fixed a cosmetic
+  error. (Robert Collins, #1430534)
+
 1.7.0
 ~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -2,23 +2,13 @@
 """Distutils installer for testtools."""
 
 from setuptools import setup
-from distutils.command.build_py import build_py
 import email
 import os
-import sys
 
 import testtools
 cmd_class = {}
 if getattr(testtools, 'TestCommand', None) is not None:
     cmd_class['test'] = testtools.TestCommand
-
-
-class testtools_build_py(build_py):
-    def build_module(self, module, module_file, package):
-        if sys.version_info >= (3,) and module == '_compat2x':
-            return
-        return build_py.build_module(self, module, module_file, package)
-cmd_class['build_py'] = testtools_build_py
 
 
 def get_version_from_pkg_info():

--- a/testtools/compat.py
+++ b/testtools/compat.py
@@ -34,7 +34,7 @@ linecache = try_import('linecache2')
 
 try:
     from testtools import _compat2x as _compat
-except (SyntaxError, ImportError):
+except SyntaxError:
     from testtools import _compat3x as _compat
 
 reraise = _compat.reraise


### PR DESCRIPTION
Building a wheel on Python 3 was missing ``_compat2x.py`` needed for Python2.
This was a side effect of the fix to bug #941958, where we fixed a cosmetic
error. (Robert Collins, #1430534)

This reverts commit 56c49a5fd420143627e50e2d0ec86e1f37075875.

Change-Id: I4de72a62b5ddf7349c432165f796841a0998e878