### PR TITLE
Fix pypy3 tests by using ceil when reporting duration.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,10 @@ Improvements
   This was a side effect of the fix to bug #941958, where we fixed a cosmetic
   error. (Robert Collins, #1430534)
 
+* During reporting in ``TextTestResult`` now always uses ``ceil`` rather than
+  depending on the undefined rounding behaviour in string formatting.
+  (Robert Collins)
+
 1.7.0
 ~~~~~
 


### PR DESCRIPTION
During reporting in ``TextTestResult`` now always uses ``ceil`` rather than
depending on the undefined rounding behaviour in string formatting.
(Robert Collins)

Change-Id: I72e11ccd1c41e9dbc65358aba5c1ffdc2d96eaf6