### PR TITLE
Clamp Sphinx below 1.3 for travis on pypy3/3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,9 @@ python:
 matrix:
   include:
     - python: "3.2"
-      env: JINJA_REQ="jinja2<2.7, Pygments<2.0"
+      env: JINJA_REQ="jinja2<2.7, Pygments<2.0, Sphinx<1.3"
+    - python: "pypy3"
+      env: JINJA_REQ="Sphinx<1.3"
 
 install:
   - pip install fixtures $JINJA_REQ sphinx


### PR DESCRIPTION
Sphinx 1.3 seems to have a bad version check added, or something.
Fixes-Bug: #1430595

Change-Id: If340c22199ba03ba987cc4544aafce0473bbbfd4