### PR TITLE
Clamp Sphinx below 1.3 for travis on pypy3/3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,24 @@ python:
   - "3.3"
   - "3.4"
   - "pypy"
-  - "pypy3"
 
 # We have to pin Jinja2 < 2.7  for Python 3.2 because 2.7 drops/breaks support:
 # http://jinja.pocoo.org/docs/changelog/#version-2-7
+# And Spinx to < 1.3 for pypy3 and python 3.2 similarly.
 #
 # See also:
 # http://stackoverflow.com/questions/18252804/syntax-error-in-jinja-2-library
 matrix:
   include:
     - python: "3.2"
-      env: JINJA_REQ="jinja2<2.7, Pygments<2.0"
+      env:
+        - JINJA_REQ="jinja2<2.7, Pygments<2.0"
+        - SPHINX="<1.3"
+    - python: "pypy3"
+      env: SPHINX="<1.3"
 
 install:
-  - pip install fixtures $JINJA_REQ sphinx
+  - pip install fixtures $JINJA_REQ sphinx$SPHINX
   - python setup.py install
 
 script:


### PR DESCRIPTION
Sphinx 1.3 seems to have a bad version check added, or something.
Fixes-Bug: #1430595

Change-Id: If340c22199ba03ba987cc4544aafce0473bbbfd4