### PR TITLE
Switch to pbr as a build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ doc/_build
 testtools.egg-info
 /build/
 /.env/
+/.eggs/
+AUTHORS
+ChangeLog

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,7 +4,4 @@ include MANIFEST.in
 include NEWS
 include README.rst
 include .gitignore
-graft doc
-graft doc/_static
-graft doc/_templates
 prune doc/_build

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -169,20 +169,16 @@ Tasks
 +++++
 
 #. Choose a version number, say X.Y.Z
-#. In trunk, ensure __init__ has version ``(X, Y, Z, 'final', 0)``
 #. Under NEXT in NEWS add a heading with the version number X.Y.Z.
 #. Possibly write a blurb into NEWS.
 #. Commit the changes.
-#. Tag the release, ``git tag -s testtools-X.Y.Z``
+#. Tag the release, ``git tag -s X.Y.Z -m "Releasing X.Y.Z"``
 #. Run 'make release', this:
    #. Creates a source distribution and uploads to PyPI
    #. Ensures all Fix Committed bugs are in the release milestone
    #. Makes a release on Launchpad and uploads the tarball
    #. Marks all the Fix Committed bugs as Fix Released
    #. Creates a new milestone
-#. Change __version__ in __init__.py to the probable next version.
-   e.g. to ``(X, Y, Z+1, 'dev', 0)``.
-#. Commit 'Opening X.Y.Z+1 for development.'
 #. If a new series has been created (e.g. 0.10.0), make the series on Launchpad.
 #. Push trunk to Github, ``git push --tags origin master``
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pbr>=0.11
+extras
+# 'mimeparse' has not been uploaded by the maintainer with Python3 compat
+# but someone kindly uploaded a fixed version as 'python-mimeparse'.
+python-mimeparse
+unittest2>=1.0.0
+traceback2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,16 @@
-[test]
-test_module = testtools.tests
-buffer=1
-catch=1
+[metadata]
+name = testtools
+summary = Extensions to the Python standard library unit testing framework
+home-page = https://github.com/testing-cabal/testtools
+description-file = doc/overview.rst
+author = Jonathan M. Lange
+author-email = jml+testtools@mumak.net
+classifier = 
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3
+
+[files]
+packages = testtools
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,83 +1,16 @@
 #!/usr/bin/env python
-"""Distutils installer for testtools."""
+import setuptools
 
-from setuptools import setup
-import email
-import os
-
-import testtools
-cmd_class = {}
-if getattr(testtools, 'TestCommand', None) is not None:
-    cmd_class['test'] = testtools.TestCommand
-
-
-def get_version_from_pkg_info():
-    """Get the version from PKG-INFO file if we can."""
-    pkg_info_path = os.path.join(os.path.dirname(__file__), 'PKG-INFO')
-    try:
-        pkg_info_file = open(pkg_info_path, 'r')
-    except (IOError, OSError):
-        return None
-    try:
-        pkg_info = email.message_from_file(pkg_info_file)
-    except email.MessageError:
-        return None
-    return pkg_info.get('Version', None)
+try:
+    import testtools
+    cmd_class = {}
+    if getattr(testtools, 'TestCommand', None) is not None:
+        cmd_class['test'] = testtools.TestCommand
+except:
+    cmd_class = None
 
 
-def get_version():
-    """Return the version of testtools that we are building."""
-    version = '.'.join(
-        str(component) for component in testtools.__version__[0:3])
-    phase = testtools.__version__[3]
-    if phase == 'final':
-        return version
-    pkg_info_version = get_version_from_pkg_info()
-    if pkg_info_version:
-        return pkg_info_version
-    # Apparently if we just say "snapshot" then distribute won't accept it
-    # as satisfying versioned dependencies. This is a problem for the
-    # daily build version.
-    return "%s.0dev0" % (version,)
-
-
-def get_long_description():
-    manual_path = os.path.join(
-        os.path.dirname(__file__), 'doc/overview.rst')
-    return open(manual_path).read()
-
-# Since we import testtools in setup.py, our setup requirements are our install
-# requirements.
-deps = [
-    'extras',
-    # 'mimeparse' has not been uploaded by the maintainer with Python3 compat
-    # but someone kindly uploaded a fixed version as 'python-mimeparse'.
-    'python-mimeparse',
-    'unittest2>=1.0.0',
-    'traceback2',
-    ]
-
-
-setup(name='testtools',
-      author='Jonathan M. Lange',
-      author_email='jml+testtools@mumak.net',
-      url='https://github.com/testing-cabal/testtools',
-      description=('Extensions to the Python standard library unit testing '
-                   'framework'),
-      long_description=get_long_description(),
-      version=get_version(),
-      classifiers=["License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
-        ],
-      packages=[
-        'testtools',
-        'testtools.matchers',
-        'testtools.testresult',
-        'testtools.tests',
-        'testtools.tests.matchers',
-        ],
-      cmdclass=cmd_class,
-      zip_safe=False,
-      install_requires=deps,
-      setup_requires=deps,
-      )
+setuptools.setup(
+    cmdclass=cmd_class,
+    setup_requires=['pbr'],
+    pbr=True)

--- a/testtools/__init__.py
+++ b/testtools/__init__.py
@@ -121,5 +121,7 @@ else:
 # established at this point, and setup.py will use a version of next-$(revno).
 # If the releaselevel is 'final', then the tarball will be major.minor.micro.
 # Otherwise it is major.minor.micro~$(revno).
-
-__version__ = (1, 8, 0, 'dev', 0)
+from pbr.version import VersionInfo
+_version = VersionInfo('testtools')
+__version__ = _version.semantic_version().version_tuple()
+version = _version.release_string()


### PR DESCRIPTION
This automates the manual dance around version numbers for less maintenance pain.

The main visible changes are:
- requirements are in requirements.txt for now
- tags must be just x.y.z not testtools-x.y.z
- version information in __init__ is dynamically looked up.
- we can probably cleanup a bunch of our bootstrap import glue but in
  the interest of clear reviews, and avoiding surprises, I'm leaving
  that alone for now.

Change-Id: Ia54f681b50764a94ada68a6b2ac1bc77bfb619c5