### PR TITLE
Fix Bug #1452436 -- Code is now PEP 396 compliant

### DIFF
--- a/testtools/__init__.py
+++ b/testtools/__init__.py
@@ -123,5 +123,6 @@ else:
 # Otherwise it is major.minor.micro~$(revno).
 from pbr.version import VersionInfo
 _version = VersionInfo('testtools')
-__version__ = _version.semantic_version().version_tuple()
+__version_info__ = _version.semantic_version().version_tuple()
+__version__ = _version.release_string()
 version = _version.release_string()


### PR DESCRIPTION
`__version__` now returns a version string instead of a tuple per [PEP 396](https://www.python.org/dev/peps/pep-0396/). Added `__version_info__` which returns a version tuple. Fixes [Bug #1451989](https://bugs.launchpad.net/testtools/+bug/1452436).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/140)
<!-- Reviewable:end -->
