### PR TITLE
Ensure fixture cleanups are called even if setUp fails with useFixture

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -662,6 +662,7 @@ class TestCase(unittest.TestCase):
         :return: The fixture, after setting it up and scheduling a cleanup for
            it.
         """
+        self.addCleanup(fixture.cleanUp)
         try:
             fixture.setUp()
         except:
@@ -678,7 +679,6 @@ class TestCase(unittest.TestCase):
                 # encountered.
                 reraise(*exc_info)
         else:
-            self.addCleanup(fixture.cleanUp)
             self.addCleanup(
                 gather_details, fixture.getDetails(), self.getDetails())
             return fixture


### PR DESCRIPTION
This change ensures that a fixture cleanUp will be called even if its
setUp fails when called by useFixture.

Example:

  class Test(testtools.TestCase):
    def test(self):
      self.useFixture(fixture)

self.useFixture ensures that fixture.cleanUp will be called even if
fixture.setUp fails.