### PR TITLE
Port twisted.deferredruntest to Twisted >= 15.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,21 +18,21 @@ python:
 matrix:
   include:
     - python: "2.6"
-      env:
-        - TWISTED_REQ="Twisted==13.0.0"
-        - TWISTED_REQ="Twisted==15.2.0"
+      env: TWISTED_REQ="Twisted==13.0.0"
+    - python: "2.6"
+      env: TWISTED_REQ="Twisted==15.2.0"
     - python: "2.7"
-      env:
-        - TWISTED_REQ="Twisted==13.0.0"
-        - TWISTED_REQ="Twisted==15.2.0"
+      env: TWISTED_REQ="Twisted==13.0.0"
+    - python: "2.7"
+      env: TWISTED_REQ="Twisted==15.2.0"
     - python: "3.2"
       env:
         - JINJA_REQ="jinja2<2.7, Pygments<2.0"
         - SPHINX="<1.3"
     - python: "pypy"
-      env:
-        - TWISTED_REQ="Twisted==13.0.0"
-        - TWISTED_REQ="Twisted==15.2.0"
+      env: TWISTED_REQ="Twisted==13.0.0"
+    - python: "pypy"
+      env: TWISTED_REQ="Twisted==15.2.0"
     - python: "pypy3"
       env: SPHINX="<1.3"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ matrix:
     - python: "2.6"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "2.6"
-      env: TWISTED_REQ="Twisted==15.2.0"
+      env: TWISTED_REQ="Twisted"
     - python: "2.7"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "2.7"
-      env: TWISTED_REQ="Twisted==15.2.0"
+      env: TWISTED_REQ="Twisted"
     - python: "3.2"
       env:
         - JINJA_REQ="jinja2<2.7, Pygments<2.0"
@@ -32,7 +32,7 @@ matrix:
     - python: "pypy"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "pypy"
-      env: TWISTED_REQ="Twisted==15.2.0"
+      env: TWISTED_REQ="Twisted"
     - python: "pypy3"
       env: SPHINX="<1.3"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ python:
   - "3.4"
   - "pypy"
 
+env:
+  - TWISTED="==13.0.0"
+  - TWISTED="==15.2.0"
+
 # We have to pin Jinja2 < 2.7  for Python 3.2 because 2.7 drops/breaks support:
 # http://jinja.pocoo.org/docs/changelog/#version-2-7
 # And Spinx to < 1.3 for pypy3 and python 3.2 similarly.
@@ -23,7 +27,7 @@ matrix:
       env: SPHINX="<1.3"
 
 install:
-  - pip install fixtures $JINJA_REQ sphinx$SPHINX
+  - pip install fixtures $JINJA_REQ sphinx$SPHINX Twisted$TWISTED
   - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,27 +7,37 @@ python:
   - "3.4"
   - "pypy"
 
-env:
-  - TWISTED="==13.0.0"
-  - TWISTED="==15.2.0"
-
 # We have to pin Jinja2 < 2.7  for Python 3.2 because 2.7 drops/breaks support:
 # http://jinja.pocoo.org/docs/changelog/#version-2-7
-# And Spinx to < 1.3 for pypy3 and python 3.2 similarly.
+# And Sphinx to < 1.3 for pypy3 and python 3.2 similarly.
 #
 # See also:
 # http://stackoverflow.com/questions/18252804/syntax-error-in-jinja-2-library
+#
+# Twisted tests currently only work on Python 2.
 matrix:
   include:
+    - python: "2.6"
+      env:
+        - TWISTED_REQ="Twisted==13.0.0"
+        - TWISTED_REQ="Twisted==15.2.0"
+    - python: "2.7"
+      env:
+        - TWISTED_REQ="Twisted==13.0.0"
+        - TWISTED_REQ="Twisted==15.2.0"
     - python: "3.2"
       env:
         - JINJA_REQ="jinja2<2.7, Pygments<2.0"
         - SPHINX="<1.3"
+    - python: "pypy"
+      env:
+        - TWISTED_REQ="Twisted==13.0.0"
+        - TWISTED_REQ="Twisted==15.2.0"
     - python: "pypy3"
       env: SPHINX="<1.3"
 
 install:
-  - pip install fixtures $JINJA_REQ sphinx$SPHINX Twisted$TWISTED
+  - pip install fixtures $JINJA_REQ sphinx$SPHINX $TWISTED_REQ
   - python setup.py install
 
 script:


### PR DESCRIPTION
Twisted 15.1.0 removes the compatibility import of _LogObserver in
twisted.trial.unittest.  This is unfortunate for us, but it's what we
get for using an internal interface.  It at least still exists in
twisted.trial._synctest, so we can get it from there.

Twisted 15.2.0 adds the new twisted.logger framework, which requires a
slight adjustment to run_with_log_observers.  There's no longer a
supported interface to get hold of all log observers, but since we're
already using an internal interface (see above), what's one more?

This passes "make check" with the current release, Twisted 15.3.0.