### PR TITLE
Allow tests to be run more than once

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,7 +10,13 @@ Changes
 -------
 
 * Add a new test dependency of testscenarios. (Robert Collins)
-  
+
+* ``addCleanup`` can now only be called during a test run.
+  (Jonathan Lange)
+
+* ``TestCase`` objects can now be run twice. All internal state is reset
+  between runs.  (Jonathan Lange)
+
 1.8.1
 ~~~~~
 

--- a/NEWS
+++ b/NEWS
@@ -29,7 +29,7 @@ Changes
 
 * Add a new test dependency of testscenarios. (Robert Collins)
 
-* ``addCleanup`` can now only be called during a test run.
+* ``addCleanup`` can now only be called within a test run.
   (Jonathan Lange)
 
 * ``TestCase`` objects can now be run twice. All internal state is reset

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -201,7 +201,6 @@ class TestCase(unittest.TestCase):
         """
         runTest = kwargs.pop('runTest', None)
         super(TestCase, self).__init__(*args, **kwargs)
-        self._cleanups = []
         self._reset()
         test_method = self._get_test_method()
         if runTest is None:
@@ -224,6 +223,7 @@ class TestCase(unittest.TestCase):
 
     def _reset(self):
         """Reset the test case as if it had never been run."""
+        self._cleanups = []
         self._unique_id_gen = itertools.count(1)
         # Generators to ensure unique traceback ids.  Maps traceback label to
         # iterators.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -201,11 +201,13 @@ class TestCase(unittest.TestCase):
         """
         runTest = kwargs.pop('runTest', None)
         super(TestCase, self).__init__(*args, **kwargs)
+        # XXX: jml: Before resubmitting, move these into _reset. We don't
+        # (yet!) have tests driving the change, but it does seem like the more
+        # correct thing to do.
         self._cleanups = []
         self._unique_id_gen = itertools.count(1)
         # Generators to ensure unique traceback ids.  Maps traceback label to
         # iterators.
-        self._traceback_id_gens = {}
         self._reset()
         test_method = self._get_test_method()
         if runTest is None:

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -639,6 +639,8 @@ class TestCase(unittest.TestCase):
                 "super(%s, self).tearDown() from your tearDown()."
                 % (sys.modules[self.__class__.__module__].__file__,
                    self.__class__.__name__))
+        self.__setup_called = False
+        self.__teardown_called = False
         return ret
 
     def _get_test_method(self):

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -630,18 +630,19 @@ class TestCase(unittest.TestCase):
         :raises ValueError: If the base class tearDown is not called, a
             ValueError is raised.
         """
-        ret = self.tearDown()
-        if not self.__teardown_called:
-            raise ValueError(
-                "In File: %s\n"
-                "TestCase.tearDown was not called. Have you upcalled all the "
-                "way up the hierarchy from your tearDown? e.g. Call "
-                "super(%s, self).tearDown() from your tearDown()."
-                % (sys.modules[self.__class__.__module__].__file__,
-                   self.__class__.__name__))
-        self.__setup_called = False
-        self.__teardown_called = False
-        return ret
+        try:
+            return self.tearDown()
+        finally:
+            if not self.__teardown_called:
+                raise ValueError(
+                    "In File: %s\n"
+                    "TestCase.tearDown was not called. Have you upcalled all the "
+                    "way up the hierarchy from your tearDown? e.g. Call "
+                    "super(%s, self).tearDown() from your tearDown()."
+                    % (sys.modules[self.__class__.__module__].__file__,
+                       self.__class__.__name__))
+            self.__setup_called = False
+            self.__teardown_called = False
 
     def _get_test_method(self):
         method_name = getattr(self, '_testMethodName')

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -201,13 +201,8 @@ class TestCase(unittest.TestCase):
         """
         runTest = kwargs.pop('runTest', None)
         super(TestCase, self).__init__(*args, **kwargs)
-        # XXX: jml: Before resubmitting, move these into _reset. We don't
-        # (yet!) have tests driving the change, but it does seem like the more
-        # correct thing to do.
         self._cleanups = []
         self._unique_id_gen = itertools.count(1)
-        # Generators to ensure unique traceback ids.  Maps traceback label to
-        # iterators.
         self._reset()
         test_method = self._get_test_method()
         if runTest is None:
@@ -230,6 +225,8 @@ class TestCase(unittest.TestCase):
 
     def _reset(self):
         """Reset the test case as if it had never been run."""
+        # Generators to ensure unique traceback ids.  Maps traceback label to
+        # iterators.
         self._traceback_id_gens = {}
         self.__setup_called = False
         self.__teardown_called = False

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -636,19 +636,16 @@ class TestCase(unittest.TestCase):
         :raises ValueError: If the base class tearDown is not called, a
             ValueError is raised.
         """
-        try:
-            return self.tearDown()
-        finally:
-            if not self.__teardown_called:
-                raise ValueError(
-                    "In File: %s\n"
-                    "TestCase.tearDown was not called. Have you upcalled all the "
-                    "way up the hierarchy from your tearDown? e.g. Call "
-                    "super(%s, self).tearDown() from your tearDown()."
-                    % (sys.modules[self.__class__.__module__].__file__,
-                       self.__class__.__name__))
-            self.__setup_called = False
-            self.__teardown_called = False
+        ret = self.tearDown()
+        if not self.__teardown_called:
+            raise ValueError(
+                "In File: %s\n"
+                "TestCase.tearDown was not called. Have you upcalled all the "
+                "way up the hierarchy from your tearDown? e.g. Call "
+                "super(%s, self).tearDown() from your tearDown()."
+                % (sys.modules[self.__class__.__module__].__file__,
+                   self.__class__.__name__))
+        return ret
 
     def _get_test_method(self):
         method_name = getattr(self, '_testMethodName')

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -206,11 +206,7 @@ class TestCase(unittest.TestCase):
         # Generators to ensure unique traceback ids.  Maps traceback label to
         # iterators.
         self._traceback_id_gens = {}
-        self.__setup_called = False
-        self.__teardown_called = False
-        # __details is lazy-initialized so that a constructed-but-not-run
-        # TestCase is safe to use with clone_test_with_new_id.
-        self.__details = None
+        self._reset()
         test_method = self._get_test_method()
         if runTest is None:
             runTest = getattr(
@@ -229,6 +225,15 @@ class TestCase(unittest.TestCase):
             (_UnexpectedSuccess, self._report_unexpected_success),
             (Exception, self._report_error),
             ]
+
+    def _reset(self):
+        """Reset the test case as if it had never been run."""
+        self._traceback_id_gens = {}
+        self.__setup_called = False
+        self.__teardown_called = False
+        # __details is lazy-initialized so that a constructed-but-not-run
+        # TestCase is safe to use with clone_test_with_new_id.
+        self.__details = None
 
     def __eq__(self, other):
         eq = getattr(unittest.TestCase, '__eq__', None)
@@ -596,6 +601,7 @@ class TestCase(unittest.TestCase):
         result.addUnexpectedSuccess(self, details=self.getDetails())
 
     def run(self, result=None):
+        self._reset()
         try:
             run_test = self.__RunTest(
                 self, self.exception_handlers, last_resort=self._report_error)

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -202,7 +202,6 @@ class TestCase(unittest.TestCase):
         runTest = kwargs.pop('runTest', None)
         super(TestCase, self).__init__(*args, **kwargs)
         self._cleanups = []
-        self._unique_id_gen = itertools.count(1)
         self._reset()
         test_method = self._get_test_method()
         if runTest is None:
@@ -225,6 +224,7 @@ class TestCase(unittest.TestCase):
 
     def _reset(self):
         """Reset the test case as if it had never been run."""
+        self._unique_id_gen = itertools.count(1)
         # Generators to ensure unique traceback ids.  Maps traceback label to
         # iterators.
         self._traceback_id_gens = {}

--- a/testtools/tests/helpers.py
+++ b/testtools/tests/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2008-2016 testtools developers. See LICENSE for details.
 
 """Helpers for tests."""
 
@@ -29,6 +29,7 @@ try:
     raise Exception
 except Exception:
     an_exc_info = sys.exc_info()
+
 
 # Deprecated: This classes attributes are somewhat non deterministic which
 # leads to hard to predict tests (because Python upstream are changing things.
@@ -153,9 +154,14 @@ class AsText(AfterPreprocessing):
             lambda log: log.as_text(), matcher, annotate=annotate)
 
 
-def throw(function, *args, **kwargs):
-    """Call ``function`` with arguments and raise the result.
+def raise_(exception):
+    """Raise ``exception``.
 
-    Use this when you want to raise within an expression.
+    Useful for raising exceptions when it is inconvenient to use a statement
+    (e.g. in a lambda).
+
+    :param Exception exception: An exception to raise.
+    :raises: Whatever exception is
+
     """
-    raise function(*args, **kwargs)
+    raise exception

--- a/testtools/tests/helpers.py
+++ b/testtools/tests/helpers.py
@@ -151,3 +151,11 @@ class AsText(AfterPreprocessing):
     def __init__(self, matcher, annotate=True):
         super(AsText, self).__init__(
             lambda log: log.as_text(), matcher, annotate=annotate)
+
+
+def throw(function, *args, **kwargs):
+    """Call ``function`` with arguments and raise the result.
+
+    Use this when you want to raise within an expression.
+    """
+    raise function(*args, **kwargs)

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2015 testtools developers. See LICENSE for details.
+
+"""A collection of sample TestCases.
+
+These are primarily of use in testing the test framework.
+"""
+
+from testtools import TestCase
+
+
+class _NormalTest(TestCase):
+
+    def test_success(self):
+        pass
+
+    def test_error(self):
+        1/0
+
+    def test_failure(self):
+        self.fail('arbitrary failure')
+
+
+"""
+A list that can be used with testscenarios to test every kind of sample
+case that we have.
+"""
+all_sample_cases_scenarios = [
+    ('simple-success-test', {'case': _NormalTest('test_success')}),
+    ('simple-error-test', {'case': _NormalTest('test_error')}),
+    ('simple-failure-test', {'case': _NormalTest('test_failure')}),
+]

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -123,6 +123,11 @@ def _make_behavior_scenarios(stage):
     )
 
 
+def make_case_for_behavior_scenario(case):
+    """Given a test with a behavior scenario installed, make a TestCase."""
+    return make_test_case(case.getUniqueString(), test_body=case.body_behavior)
+
+
 class _TearDownFails(TestCase):
     """Passing test case with failing tearDown after upcall."""
 

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -42,7 +42,8 @@ class _SetUpFailsOnGlobalState(TestCase):
     """Fail to upcall setUp on first run. Fail to upcall tearDown after.
 
     This simulates a test that fails to upcall in ``setUp`` if some global
-    state is broken, and fails to call ``tearDown`` at all.
+    state is broken, and fails to call ``tearDown`` when the global state
+    breaks but works after that.
     """
 
     first_run = True

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -138,12 +138,16 @@ def _make_behavior_scenarios(stage):
 
 def make_case_for_behavior_scenario(case):
     """Given a test with a behavior scenario installed, make a TestCase."""
+    cleanup_behavior = getattr(case, 'cleanup_behavior', None)
+    cleanups = [cleanup_behavior] if cleanup_behavior else []
     return make_test_case(
         case.getUniqueString(),
-        set_up=case.set_up_behavior,
-        test_body=case.body_behavior,
-        tear_down=case.tear_down_behavior,
-        cleanups=(case.cleanup_behavior,),
+        set_up=getattr(case, 'set_up_behavior', _do_nothing),
+        test_body=getattr(case, 'body_behavior', _do_nothing),
+        tear_down=getattr(case, 'tear_down_behavior', _do_nothing),
+        cleanups=cleanups,
+        pre_set_up=getattr(case, 'pre_set_up_behavior', _do_nothing),
+        post_tear_down=getattr(case, 'post_tear_down_behavior', _do_nothing),
     )
 
 

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -51,7 +51,7 @@ class _ConstructedTest(TestCase):
 
     def __init__(self, test_method_name, set_up, test_body, tear_down,
                  cleanups, pre_set_up, post_tear_down):
-        setattr(self, test_method_name, test_body)
+        setattr(self, test_method_name, self.test_case)
         super(_ConstructedTest, self).__init__(test_method_name)
         self._set_up = set_up
         self._test_body = test_body

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -91,6 +91,38 @@ def _unexpected_success(case):
     case.expectFailure('arbitrary unexpected success', _success)
 
 
+behaviors = [
+    ('success', _success),
+    ('fail', _failure),
+    ('error',  _error),
+    ('skip', _skip),
+    ('xfail', _expected_failure),
+    ('uxsuccess', _unexpected_success),
+]
+
+
+def _make_behavior_scenarios(stage):
+    """Given a test stage, iterate over behavior scenarios for that stage.
+
+    e.g.
+        >>> list(_make_behavior_scenarios('setUp'))
+        [('setUp=success', {'setUp_behavior': <function _success>}),
+         ('setUp=fail', {'setUp_behavior': <function _failure>}),
+         ('setUp=error', {'setUp_behavior': <function _error>}),
+         ('setUp=skip', {'setUp_behavior': <function _skip>}),
+         ('setUp=xfail', {'setUp_behavior': <function _expected_failure>),
+         ('setUp=uxsuccess',
+          {'setUp_behavior': <function _unexpected_success>})]
+
+    Ordering is not consistent.
+    """
+    return (
+        ('%s=%s' % (stage, behavior),
+         {'%s_behavior' % (stage,): function})
+        for (behavior, function) in behaviors
+    )
+
+
 class _TearDownFails(TestCase):
     """Passing test case with failing tearDown after upcall."""
 
@@ -162,25 +194,14 @@ def _test_error_traceback(case, traceback_matcher):
 A list that can be used with testscenarios to test every deterministic sample
 case that we have.
 """
-deterministic_sample_cases_scenarios = [
-    ('simple-success-test', {
-        'case': make_test_case('test_success', test_body=_success)
-    }),
-    ('simple-error-test', {
-        'case': make_test_case('test_error', test_body=_error)
-    }),
-    ('simple-failure-test', {
-        'case': make_test_case('test_failure', test_body=_failure)
-    }),
-    ('simple-expected-failure-test', {
-        'case': make_test_case('test_failure', test_body=_expected_failure)
-    }),
-    ('simple-unexpected-success-test', {
-        'case': make_test_case('test_failure', test_body=_unexpected_success)
-    }),
-    ('simple-skip-test', {
-        'case': make_test_case('test_failure', test_body=_skip)
-    }),
+deterministic_sample_cases_scenarios = _make_behavior_scenarios('body')
+
+
+"""
+A list that can be used with testscenarios to test deterministic cases
+that we cannot easily construct from our test behavior matrix.
+"""
+special_deterministic_sample_cases_scenarios = [
     ('teardown-fails', {'case': _TearDownFails('test_success')}),
 ]
 

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -20,6 +20,17 @@ class _NormalTest(TestCase):
         self.fail('arbitrary failure')
 
 
+class _TearDownFails(TestCase):
+    """Passing test case with failing tearDown after upcall."""
+
+    def test_success(self):
+        pass
+
+    def tearDown(self):
+        super(_TearDownFails, self).tearDown()
+        1/0
+
+
 """
 A list that can be used with testscenarios to test every kind of sample
 case that we have.
@@ -28,4 +39,5 @@ all_sample_cases_scenarios = [
     ('simple-success-test', {'case': _NormalTest('test_success')}),
     ('simple-error-test', {'case': _NormalTest('test_error')}),
     ('simple-failure-test', {'case': _NormalTest('test_failure')}),
+    ('teardown-fails', {'case': _TearDownFails('test_success')}),
 ]

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -63,11 +63,23 @@ def _success(case):
 
 
 def _error(case):
-    1/0
+    1/0  # arbitrary non-failure exception
 
 
 def _failure(case):
     case.fail('arbitrary failure')
+
+
+def _skip(case):
+    case.skip('arbitrary skip message')
+
+
+def _expected_failure(case):
+    case.expectFailure('arbitrary expected failure', _failure, case)
+
+
+def _unexpected_success(case):
+    case.expectFailure('arbitrary unexpected success', _success)
 
 
 class _TearDownFails(TestCase):
@@ -150,6 +162,15 @@ deterministic_sample_cases_scenarios = [
     }),
     ('simple-failure-test', {
         'case': _ConstructedTest('test_failure', test_body=_failure)
+    }),
+    ('simple-expected-failure-test', {
+        'case': _ConstructedTest('test_failure', test_body=_expected_failure)
+    }),
+    ('simple-unexpected-success-test', {
+        'case': _ConstructedTest('test_failure', test_body=_unexpected_success)
+    }),
+    ('simple-skip-test', {
+        'case': _ConstructedTest('test_failure', test_body=_skip)
     }),
     ('teardown-fails', {'case': _TearDownFails('test_success')}),
 ]

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -6,6 +6,13 @@ These are primarily of use in testing the test framework.
 """
 
 from testtools import TestCase
+from testtools.matchers import (
+    AfterPreprocessing,
+    Contains,
+    Equals,
+    MatchesDict,
+    MatchesListwise,
+)
 
 
 class _NormalTest(TestCase):
@@ -31,6 +38,61 @@ class _TearDownFails(TestCase):
         1/0
 
 
+class _SetUpFailsOnGlobalState(TestCase):
+    """Fail to upcall setUp on first run. Fail to upcall tearDown after.
+
+    This simulates a test that fails to upcall in ``setUp`` if some global
+    state is broken, and fails to call ``tearDown`` at all.
+    """
+
+    first_run = True
+
+    def setUp(self):
+        if not self.first_run:
+            return
+        super(_SetUpFailsOnGlobalState, self).setUp()
+
+    def test_success(self):
+        pass
+
+    def tearDown(self):
+        if not self.first_run:
+            super(_SetUpFailsOnGlobalState, self).tearDown()
+        self.__class__.first_run = False
+
+    @classmethod
+    def make_scenario(cls):
+        case = cls('test_success')
+        return {
+            'case': case,
+            'expected_first_result': _test_error_traceback(
+                case, Contains('TestCase.tearDown was not called')),
+            'expected_second_result': _test_error_traceback(
+                case, Contains('TestCase.setUp was not called')),
+        }
+
+
+def _test_error_traceback(case, traceback_matcher):
+    """Match result log of single test that errored out.
+
+    ``traceback_matcher`` is applied to the text of the traceback.
+    """
+    return MatchesListwise([
+        Equals(('startTest', case)),
+        MatchesListwise([
+            Equals('addError'),
+            Equals(case),
+            MatchesDict({
+                'traceback': AfterPreprocessing(
+                    lambda x: x.as_text(),
+                    traceback_matcher,
+                )
+            })
+        ]),
+        Equals(('stopTest', case)),
+    ])
+
+
 """
 A list that can be used with testscenarios to test every deterministic sample
 case that we have.
@@ -40,4 +102,13 @@ deterministic_sample_cases_scenarios = [
     ('simple-error-test', {'case': _NormalTest('test_error')}),
     ('simple-failure-test', {'case': _NormalTest('test_failure')}),
     ('teardown-fails', {'case': _TearDownFails('test_success')}),
+]
+
+
+"""
+A list that can be used with testscenarios to test every non-deterministic
+sample case that we have.
+"""
+nondeterministic_sample_cases_scenarios = [
+    ('setup-fails-global-state', _SetUpFailsOnGlobalState.make_scenario()),
 ]

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -18,7 +18,8 @@ from testtools.matchers import (
 
 
 def make_test_case(test_method_name, set_up=None, test_body=None,
-                   tear_down=None, cleanups=()):
+                   tear_down=None, cleanups=(), pre_set_up=None,
+                   post_tear_down=None):
     """Make a test case with the given behaviors.
 
     All callables are unary callables that receive this test as their argument.
@@ -29,29 +30,38 @@ def make_test_case(test_method_name, set_up=None, test_body=None,
         assigned to the test method.
     :param callable tear_down: Implementation of tearDown.
     :param cleanups: Iterable of callables that will be added as cleanups.
+    :param callable pre_set_up: Called before the upcall to setUp().
+    :param callable post_tear_down: Called after the upcall to tearDown().
 
     :return: A ``testtools.TestCase``.
     """
     set_up = set_up if set_up else _do_nothing
     test_body = test_body if test_body else _do_nothing
     tear_down = tear_down if tear_down else _do_nothing
+    pre_set_up = pre_set_up if pre_set_up else _do_nothing
+    post_tear_down = post_tear_down if post_tear_down else _do_nothing
     return _ConstructedTest(
-        test_method_name, set_up, test_body, tear_down, cleanups)
+        test_method_name, set_up, test_body, tear_down, cleanups,
+        pre_set_up, post_tear_down,
+    )
 
 
 class _ConstructedTest(TestCase):
     """A test case where all of the stages."""
 
     def __init__(self, test_method_name, set_up, test_body, tear_down,
-                 cleanups):
+                 cleanups, pre_set_up, post_tear_down):
         setattr(self, test_method_name, test_body)
         super(_ConstructedTest, self).__init__(test_method_name)
         self._set_up = set_up
         self._test_body = test_body
         self._tear_down = tear_down
         self._test_cleanups = cleanups
+        self._pre_set_up = pre_set_up
+        self._post_tear_down = post_tear_down
 
     def setUp(self):
+        self._pre_set_up(self)
         super(_ConstructedTest, self).setUp()
         for cleanup in self._test_cleanups:
             self.addCleanup(cleanup, self)
@@ -63,6 +73,7 @@ class _ConstructedTest(TestCase):
     def tearDown(self):
         self._tear_down(self)
         super(_ConstructedTest, self).tearDown()
+        self._post_tear_down(self)
 
 
 def _do_nothing(case):

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -47,10 +47,14 @@ def make_test_case(test_method_name, set_up=None, test_body=None,
 
 
 class _ConstructedTest(TestCase):
-    """A test case where all of the stages."""
+    """A test case defined by arguments, rather than overrides."""
 
     def __init__(self, test_method_name, set_up, test_body, tear_down,
                  cleanups, pre_set_up, post_tear_down):
+        """Construct a test case.
+
+        See ``make_test_case`` for full documentation.
+        """
         setattr(self, test_method_name, self.test_case)
         super(_ConstructedTest, self).__init__(test_method_name)
         self._set_up = set_up
@@ -80,8 +84,7 @@ def _do_nothing(case):
     pass
 
 
-def _success(case):
-    pass
+_success = _do_nothing
 
 
 def _error(case):
@@ -101,7 +104,7 @@ def _expected_failure(case):
 
 
 def _unexpected_success(case):
-    case.expectFailure('arbitrary unexpected success', _success)
+    case.expectFailure('arbitrary unexpected success', _success, case)
 
 
 behaviors = [

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -32,10 +32,10 @@ class _TearDownFails(TestCase):
 
 
 """
-A list that can be used with testscenarios to test every kind of sample
+A list that can be used with testscenarios to test every deterministic sample
 case that we have.
 """
-all_sample_cases_scenarios = [
+deterministic_sample_cases_scenarios = [
     ('simple-success-test', {'case': _NormalTest('test_success')}),
     ('simple-error-test', {'case': _NormalTest('test_error')}),
     ('simple-failure-test', {'case': _NormalTest('test_failure')}),

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -151,17 +151,6 @@ def make_case_for_behavior_scenario(case):
     )
 
 
-class _TearDownFails(TestCase):
-    """Passing test case with failing tearDown after upcall."""
-
-    def test_success(self):
-        pass
-
-    def tearDown(self):
-        super(_TearDownFails, self).tearDown()
-        1/0
-
-
 class _SetUpFailsOnGlobalState(TestCase):
     """Fail to upcall setUp on first run. Fail to upcall tearDown after.
 
@@ -227,15 +216,10 @@ deterministic_sample_cases_scenarios = multiply_scenarios(
     _make_behavior_scenarios('body'),
     _make_behavior_scenarios('tear_down'),
     _make_behavior_scenarios('cleanup'),
-)
-
-
-"""
-A list that can be used with testscenarios to test deterministic cases
-that we cannot easily construct from our test behavior matrix.
-"""
-special_deterministic_sample_cases_scenarios = [
-    ('teardown-fails', {'case': _TearDownFails('test_success')}),
+) + [
+    ('tear_down_fails_after_upcall', {
+        'post_tear_down_behavior': _error,
+    }),
 ]
 
 

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -118,14 +118,14 @@ def _make_behavior_scenarios(stage):
     """Given a test stage, iterate over behavior scenarios for that stage.
 
     e.g.
-        >>> list(_make_behavior_scenarios('setUp'))
-        [('setUp=success', {'setUp_behavior': <function _success>}),
-         ('setUp=fail', {'setUp_behavior': <function _failure>}),
-         ('setUp=error', {'setUp_behavior': <function _error>}),
-         ('setUp=skip', {'setUp_behavior': <function _skip>}),
-         ('setUp=xfail', {'setUp_behavior': <function _expected_failure>),
-         ('setUp=uxsuccess',
-          {'setUp_behavior': <function _unexpected_success>})]
+        >>> list(_make_behavior_scenarios('set_up'))
+        [('set_up=success', {'set_up_behavior': <function _success>}),
+         ('set_up=fail', {'set_up_behavior': <function _failure>}),
+         ('set_up=error', {'set_up_behavior': <function _error>}),
+         ('set_up=skip', {'set_up_behavior': <function _skip>}),
+         ('set_up=xfail', {'set_up_behavior': <function _expected_failure>),
+         ('set_up=uxsuccess',
+          {'set_up_behavior': <function _unexpected_success>})]
 
     Ordering is not consistent.
     """

--- a/testtools/tests/test_deferredruntest.py
+++ b/testtools/tests/test_deferredruntest.py
@@ -13,20 +13,21 @@ from testtools import (
     TestResult,
     )
 from testtools.matchers import (
-    AfterPreprocessing,
     ContainsAll,
     EndsWith,
     Equals,
     Is,
     KeysEqual,
-    MatchesDict,
     MatchesException,
-    MatchesListwise,
     Not,
     Raises,
     )
 from testtools.runtest import RunTest
 from testtools.testresult.doubles import ExtendedTestResult
+from testtools.tests.helpers import (
+    AsText,
+    MatchesEvents,
+)
 from testtools.tests.test_spinner import NeedsTwistedTestCase
 
 assert_fails_with = try_import('testtools.deferredruntest.assert_fails_with')
@@ -41,45 +42,6 @@ defer = try_import('twisted.internet.defer')
 failure = try_import('twisted.python.failure')
 log = try_import('twisted.python.log')
 DelayedCall = try_import('twisted.internet.base.DelayedCall')
-
-
-class MatchesEvents(object):
-    """Match a list of test result events.
-
-    Specify events as a data structure.  Ordinary Python objects within this
-    structure will be compared exactly, but you can also use matchers at any
-    point.
-    """
-
-    def __init__(self, *expected):
-        self._expected = expected
-
-    def _make_matcher(self, obj):
-        # This isn't very safe for general use, but is good enough to make
-        # some tests in this module more readable.
-        if hasattr(obj, 'match'):
-            return obj
-        elif isinstance(obj, tuple) or isinstance(obj, list):
-            return MatchesListwise(
-                [self._make_matcher(item) for item in obj])
-        elif isinstance(obj, dict):
-            return MatchesDict(dict(
-                (key, self._make_matcher(value))
-                for key, value in obj.items()))
-        else:
-            return Equals(obj)
-
-    def match(self, observed):
-        matcher = self._make_matcher(self._expected)
-        return matcher.match(observed)
-
-
-class AsText(AfterPreprocessing):
-    """Match the text of a Content instance."""
-
-    def __init__(self, matcher, annotate=True):
-        super(AsText, self).__init__(
-            lambda log: log.as_text(), matcher, annotate=annotate)
 
 
 class X(object):

--- a/testtools/tests/test_runtest.py
+++ b/testtools/tests/test_runtest.py
@@ -72,9 +72,9 @@ class TestRunTest(TestCase):
         class Case(TestCase):
             def test(self):
                 raise KeyboardInterrupt("go")
-            def tearDown(self):
+            def _run_teardown(self, result):
                 tearDownRuns.append(self)
-                super(Case, self).tearDown()
+                return super(Case, self)._run_teardown(result)
         case = Case('test')
         run = RunTest(case)
         run.result = ExtendedTestResult()

--- a/testtools/tests/test_runtest.py
+++ b/testtools/tests/test_runtest.py
@@ -9,7 +9,7 @@ from testtools import (
     TestCase,
     TestResult,
     )
-from testtools.matchers import MatchesException, Is, Raises
+from testtools.matchers import HasLength, MatchesException, Is, Raises
 from testtools.testresult.doubles import ExtendedTestResult
 from testtools.tests.helpers import FullStackRunTest
 
@@ -68,9 +68,13 @@ class TestRunTest(TestCase):
         self.assertEqual(['foo'], log)
 
     def test__run_prepared_result_does_not_mask_keyboard(self):
+        tearDownRuns = []
         class Case(TestCase):
             def test(self):
                 raise KeyboardInterrupt("go")
+            def tearDown(self):
+                tearDownRuns.append(self)
+                super(Case, self).tearDown()
         case = Case('test')
         run = RunTest(case)
         run.result = ExtendedTestResult()
@@ -79,7 +83,7 @@ class TestRunTest(TestCase):
         self.assertEqual(
             [('startTest', case), ('stopTest', case)], run.result._events)
         # tearDown is still run though!
-        self.assertEqual(True, getattr(case, '_TestCase__teardown_called'))
+        self.assertThat(tearDownRuns, HasLength(1))
 
     def test__run_user_calls_onException(self):
         case = self.make_case()

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1265,6 +1265,18 @@ class TestSetupTearDown(TestCase):
                 "...ValueError...File...testtools/tests/test_testcase.py...",
                 ELLIPSIS))
 
+    def test_runTwice(self):
+        # Tests can be run twice.
+        class NormalTest(TestCase):
+            def test_method(self):
+                pass
+        test = NormalTest('test_method')
+        result = unittest.TestResult()
+        test.run(result)
+        test.run(result)
+        self.expectThat(result.errors, HasLength(0))
+        self.assertThat(result.testsRun, Equals(2))
+
 
 require_py27_minimum = skipIf(
     sys.version < '2.7',

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1268,6 +1268,15 @@ class TestSetupTearDown(TestCase):
                 "...ValueError...File...testtools/tests/test_testcase.py...",
                 ELLIPSIS))
 
+
+class TestRunTwice(TestCase):
+    """Can we run the same test case twice?"""
+
+    # XXX: Reviewer, please note that all of the other test cases in this
+    # module are doing this wrong, saying 'run_test_with' instead of
+    # 'run_tests_with'.
+    run_tests_with = FullStackRunTest
+
     def test_runTwice(self):
         # Tests can be run twice.
         class NormalTest(TestCase):

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -53,7 +53,7 @@ from testtools.tests.helpers import (
     )
 from testtools.tests.samplecases import (
     deterministic_sample_cases_scenarios,
-    make_test_case,
+    make_case_for_behavior_scenario,
     nondeterministic_sample_cases_scenarios,
     special_deterministic_sample_cases_scenarios,
 )
@@ -1286,11 +1286,7 @@ class TestRunTwiceDeterminstic(TestCase):
         # Tests that are intrinsically determistic can be run twice and
         # produce exactly the same results each time, without need for
         # explicit resetting or reconstruction.
-
-        # XXX: jml: before resubmitting. Although make_test_case should be
-        # exported, it's a bit wrong to be relying on internal details of the
-        # scenario generation here.
-        test = make_test_case('test_arbitrary', test_body=self.body_behavior)
+        test = make_case_for_behavior_scenario(self)
         first_result = ExtendedTestResult()
         test.run(first_result)
         second_result = ExtendedTestResult()

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -54,6 +54,7 @@ from testtools.tests.helpers import (
     FullStackRunTest,
     LoggingResult,
     )
+from testtools.tests.samplecases import all_sample_cases_scenarios
 
 
 class TestPlaceHolder(TestCase):
@@ -1277,19 +1278,21 @@ class TestRunTwice(TestCase):
     # 'run_tests_with'.
     run_tests_with = FullStackRunTest
 
+    scenarios = all_sample_cases_scenarios
+
     def test_runTwice(self):
-        # Tests can be run twice.
-        class NormalTest(TestCase):
-            def test_method(self):
-                pass
-        test = NormalTest('test_method')
-        result = unittest.TestResult()
-        test.run(result)
-        test.run(result)
-        self.expectThat(result.errors, HasLength(0))
-        self.assertThat(result.testsRun, Equals(2))
+        # Tests that are intrinsically determistic can be run twice and
+        # produce exactly the same results each time, without need for
+        # explicit resetting or reconstruction.
+        test = self.case
+        first_result = ExtendedTestResult()
+        test.run(first_result)
+        second_result = ExtendedTestResult()
+        test.run(second_result)
+        self.assertEqual(first_result._events, second_result._events)
 
     def test_runTwiceTearDownFailure(self):
+        # XXX: jml: you should move this into _samplecases.
         # Tests can be run twice, even if tearDown fails.
         class NormalTest(TestCase):
             def test_method(self):

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -53,6 +53,7 @@ from testtools.tests.helpers import (
     FullStackRunTest,
     LoggingResult,
     MatchesEvents,
+    throw,
     )
 from testtools.tests.samplecases import (
     deterministic_sample_cases_scenarios,
@@ -863,10 +864,8 @@ class TestAddCleanup(TestCase):
 
     def test_keyboard_interrupt_not_caught(self):
         # If a cleanup raises KeyboardInterrupt, it gets reraised.
-        def raise_keyboard_interrupt(ignored):
-            raise KeyboardInterrupt()
         test = make_test_case(
-            self.getUniqueString(), cleanups=[raise_keyboard_interrupt])
+            self.getUniqueString(), cleanups=[lambda _: throw(KeyboardInterrupt)])
         self.assertThat(test.run, Raises(MatchesException(KeyboardInterrupt)))
 
     def test_all_errors_from_MultipleExceptions_reported(self):
@@ -931,12 +930,9 @@ class TestAddCleanup(TestCase):
     def test_multipleErrorsCoreAndCleanupReported(self):
         # Errors from all failing cleanups are reported, with stopTest,
         # startTest inserted.
-        def broken_test(ignored):
-            raise RuntimeError('Deliberately broken test')
-
         test = make_test_case(
             self.getUniqueString(),
-            test_body=broken_test,
+            test_body=lambda _: throw(RuntimeError, 'Deliberately broken test'),
             cleanups=[
                 lambda _: 1/0,
                 lambda _: 1/0,

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -54,7 +54,10 @@ from testtools.tests.helpers import (
     FullStackRunTest,
     LoggingResult,
     )
-from testtools.tests.samplecases import deterministic_sample_cases_scenarios
+from testtools.tests.samplecases import (
+    deterministic_sample_cases_scenarios,
+    nondeterministic_sample_cases_scenarios,
+)
 
 
 class TestPlaceHolder(TestCase):
@@ -1270,7 +1273,7 @@ class TestSetupTearDown(TestCase):
                 ELLIPSIS))
 
 
-class TestRunTwice(TestCase):
+class TestRunTwiceDeterminstic(TestCase):
     """Can we run the same test case twice?"""
 
     # XXX: Reviewer, please note that all of the other test cases in this
@@ -1290,6 +1293,29 @@ class TestRunTwice(TestCase):
         second_result = ExtendedTestResult()
         test.run(second_result)
         self.assertEqual(first_result._events, second_result._events)
+
+
+class TestRunTwiceNondeterministic(TestCase):
+    """Can we run the same test case twice?
+
+    Separate suite for non-deterministic tests, which require more complicated
+    assertions and scenarios.
+    """
+
+    run_tests_with = FullStackRunTest
+
+    scenarios = nondeterministic_sample_cases_scenarios
+
+    def test_runTwice(self):
+        test = self.case
+        first_result = ExtendedTestResult()
+        test.run(first_result)
+        second_result = ExtendedTestResult()
+        test.run(second_result)
+        self.expectThat(
+            first_result._events, self.expected_first_result)
+        self.assertThat(
+            second_result._events, self.expected_second_result)
 
 
 require_py27_minimum = skipIf(

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
 """Tests for extensions to the base test library."""
 
@@ -55,7 +55,6 @@ from testtools.tests.samplecases import (
     deterministic_sample_cases_scenarios,
     make_case_for_behavior_scenario,
     nondeterministic_sample_cases_scenarios,
-    special_deterministic_sample_cases_scenarios,
 )
 
 
@@ -1287,25 +1286,6 @@ class TestRunTwiceDeterminstic(TestCase):
         # produce exactly the same results each time, without need for
         # explicit resetting or reconstruction.
         test = make_case_for_behavior_scenario(self)
-        first_result = ExtendedTestResult()
-        test.run(first_result)
-        second_result = ExtendedTestResult()
-        test.run(second_result)
-        self.assertEqual(first_result._events, second_result._events)
-
-
-class TestRunTwiceDeterminsticSpecial(TestCase):
-    """Can we run the same test case twice?"""
-
-    run_tests_with = FullStackRunTest
-
-    scenarios = special_deterministic_sample_cases_scenarios
-
-    def test_runTwice(self):
-        # Tests that are intrinsically determistic can be run twice and
-        # produce exactly the same results each time, without need for
-        # explicit resetting or reconstruction.
-        test = self.case
         first_result = ExtendedTestResult()
         test.run(first_result)
         second_result = ExtendedTestResult()

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -54,7 +54,7 @@ from testtools.tests.helpers import (
     FullStackRunTest,
     LoggingResult,
     )
-from testtools.tests.samplecases import all_sample_cases_scenarios
+from testtools.tests.samplecases import deterministic_sample_cases_scenarios
 
 
 class TestPlaceHolder(TestCase):
@@ -1278,7 +1278,7 @@ class TestRunTwice(TestCase):
     # 'run_tests_with'.
     run_tests_with = FullStackRunTest
 
-    scenarios = all_sample_cases_scenarios
+    scenarios = deterministic_sample_cases_scenarios
 
     def test_runTwice(self):
         # Tests that are intrinsically determistic can be run twice and

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -53,7 +53,7 @@ from testtools.tests.helpers import (
     FullStackRunTest,
     LoggingResult,
     MatchesEvents,
-    throw,
+    raise_,
     )
 from testtools.tests.samplecases import (
     deterministic_sample_cases_scenarios,
@@ -885,7 +885,8 @@ class TestAddCleanup(TestCase):
     def test_keyboard_interrupt_not_caught(self):
         # If a cleanup raises KeyboardInterrupt, it gets reraised.
         test = make_test_case(
-            self.getUniqueString(), cleanups=[lambda _: throw(KeyboardInterrupt)])
+            self.getUniqueString(), cleanups=[
+                lambda _: raise_(KeyboardInterrupt())])
         self.assertThat(test.run, Raises(MatchesException(KeyboardInterrupt)))
 
     def test_all_errors_from_MultipleExceptions_reported(self):
@@ -952,7 +953,8 @@ class TestAddCleanup(TestCase):
         # startTest inserted.
         test = make_test_case(
             self.getUniqueString(),
-            test_body=lambda _: throw(RuntimeError, 'Deliberately broken test'),
+            test_body=lambda _: raise_(
+                RuntimeError('Deliberately broken test')),
             cleanups=[
                 lambda _: 1/0,
                 lambda _: 1/0,

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1291,34 +1291,6 @@ class TestRunTwice(TestCase):
         test.run(second_result)
         self.assertEqual(first_result._events, second_result._events)
 
-    def test_runTwiceTearDownFailure(self):
-        # XXX: jml: you should move this into _samplecases.
-        # Tests can be run twice, even if tearDown fails.
-        class NormalTest(TestCase):
-            def test_method(self):
-                pass
-            def tearDown(self):
-                super(NormalTest, self).tearDown()
-                1/0
-        test = NormalTest('test_method')
-        result = unittest.TestResult()
-        test.run(result)
-        # We don't want the errors of the first test to appear in the last
-        # test.
-        test.getDetails().clear()
-        test.run(result)
-        self.expectThat(result.testsRun, Equals(2))
-        # We have code that discourages people from calling setUp()
-        # explicitly. Here we make sure that this code is not being activated
-        # when we run a test twice.
-        def count_tracebacks(exception):
-            """Number of tracebacks in exception."""
-            return str(exception).count('Traceback (most recent call last):')
-        self.assertThat(
-            [e[1] for e in result.errors],
-            AllMatch(
-                MatchesAll(AfterPreprocessing(count_tracebacks, Equals(1)))))
-
 
 require_py27_minimum = skipIf(
     sys.version < '2.7',

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -29,13 +29,10 @@ from testtools.content import (
     TracebackContent,
     )
 from testtools.matchers import (
-    AfterPreprocessing,
-    AllMatch,
     Annotate,
     DocTestMatches,
     Equals,
     HasLength,
-    MatchesAll,
     MatchesException,
     Raises,
     )
@@ -56,7 +53,9 @@ from testtools.tests.helpers import (
     )
 from testtools.tests.samplecases import (
     deterministic_sample_cases_scenarios,
+    make_test_case,
     nondeterministic_sample_cases_scenarios,
+    special_deterministic_sample_cases_scenarios,
 )
 
 
@@ -1282,6 +1281,29 @@ class TestRunTwiceDeterminstic(TestCase):
     run_tests_with = FullStackRunTest
 
     scenarios = deterministic_sample_cases_scenarios
+
+    def test_runTwice(self):
+        # Tests that are intrinsically determistic can be run twice and
+        # produce exactly the same results each time, without need for
+        # explicit resetting or reconstruction.
+
+        # XXX: jml: before resubmitting. Although make_test_case should be
+        # exported, it's a bit wrong to be relying on internal details of the
+        # scenario generation here.
+        test = make_test_case('test_arbitrary', test_body=self.body_behavior)
+        first_result = ExtendedTestResult()
+        test.run(first_result)
+        second_result = ExtendedTestResult()
+        test.run(second_result)
+        self.assertEqual(first_result._events, second_result._events)
+
+
+class TestRunTwiceDeterminsticSpecial(TestCase):
+    """Can we run the same test case twice?"""
+
+    run_tests_with = FullStackRunTest
+
+    scenarios = special_deterministic_sample_cases_scenarios
 
     def test_runTwice(self):
         # Tests that are intrinsically determistic can be run twice and


### PR DESCRIPTION
Our `setUp` and `tearDown` protection would prevent a single test from being run more than once. This makes a `RunTest`-based solution to [#1515933 - Support for retrying intermittently failing tests](https://bugs.launchpad.net/testtools/+bug/1515933) rather difficult.

This patch makes it possible to re-run tests, failed or otherwise. AFAICT, it doesn't change any of our public APIs.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/165)
<!-- Reviewable:end -->
