### PR TITLE
Become compatible with newer Fixtures _setUp() API.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,6 +19,7 @@ The testtools authors are:
  * Vincent Ladeuil
  * Nikola Đipanov
  * Tristan Seligmann
+ * Julian Edwards
 
 and are collectively referred to as "testtools developers".
 

--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,10 @@ Improvements
   report the lack of result as a test error. This ought to make weird
   concurrency interaction bugs easier to understand. (Jonathan Lange)
 
+* Previously, when gathering details caused by a setUp() failure,
+  a traceback occurred if the fixture used the newer _setUp().
+  This had the side effect of not clearing up fixtures nor gathering details
+  properly.  This is now fixed.  (Julian Edwards #1469759)
 
 2.0.0
 ~~~~~

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -685,7 +685,8 @@ class TestCase(unittest.TestCase):
         try:
             fixture.setUp()
         except MultipleExceptions as e:
-            if e.args[-1][0] is fixtures.fixture.SetupError:
+            if (fixtures is not None and
+                    e.args[-1][0] is fixtures.fixture.SetupError):
                 gather_details(e.args[-1][1].args[0], self.getDetails())
             raise
         except:

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -26,6 +26,7 @@ from extras import (
     try_import,
     try_imports,
     )
+fixtures = try_import('fixtures')
 # To let setup.py work, make this a conditional import.
 unittest = try_imports(['unittest2', 'unittest'])
 
@@ -49,7 +50,10 @@ from testtools.matchers import (
     )
 from testtools.matchers._basic import _FlippedEquals
 from testtools.monkey import patch
-from testtools.runtest import RunTest
+from testtools.runtest import (
+    MultipleExceptions,
+    RunTest,
+    )
 from testtools.testresult import (
     ExtendedToOriginalDecorator,
     TestResult,
@@ -680,6 +684,10 @@ class TestCase(unittest.TestCase):
         """
         try:
             fixture.setUp()
+        except MultipleExceptions as e:
+            if e.args[-1][0] is fixtures.fixture.SetupError:
+                gather_details(e.args[-1][1].args[0], self.getDetails())
+            raise
         except:
             exc_info = sys.exc_info()
             try:

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -683,7 +683,14 @@ class TestCase(unittest.TestCase):
         except:
             exc_info = sys.exc_info()
             try:
-                gather_details(fixture.getDetails(), self.getDetails())
+                # fixture._details is not available if using the newer
+                # _setUp() API in Fixtures because it already cleaned up
+                # the fixture.  Ideally this whole try/except is not
+                # really needed any more, however, we keep this code to
+                # remain compatible with the older setUp().
+                if (safe_hasattr(fixture, '_details') and
+                        fixture._details is not None):
+                    gather_details(fixture.getDetails(), self.getDetails())
             except:
                 # Report the setUp exception, then raise the error during
                 # gather_details.

--- a/testtools/tests/test_fixturesupport.py
+++ b/testtools/tests/test_fixturesupport.py
@@ -10,14 +10,16 @@ from testtools import (
     content_type,
     )
 from testtools.compat import _b, _u
-from testtools.matchers import Contains
+from testtools.matchers import (
+    Contains,
+    Equals,
+    )
 from testtools.testresult.doubles import (
     ExtendedTestResult,
     )
 
 fixtures = try_import('fixtures')
 LoggingFixture = try_import('fixtures.tests.helpers.LoggingFixture')
-
 
 class TestFixtureSupport(TestCase):
 
@@ -120,21 +122,30 @@ class TestFixtureSupport(TestCase):
         class BrokenFixture(fixtures.Fixture):
             def _setUp(self):
                 fixtures.Fixture._setUp(self)
-                self.addDetail('content', content.text_content("foobar"))
+                self.addDetail('broken', content.text_content("foobar"))
                 raise Exception("_setUp broke")
         fixture = BrokenFixture()
         class SimpleTest(TestCase):
             def test_foo(self):
+                self.addDetail('foo_content', content.text_content("foo ok"))
                 self.useFixture(fixture)
         result = ExtendedTestResult()
         SimpleTest('test_foo').run(result)
         self.assertEqual('addError', result._events[-2][0])
         details = result._events[-2][2]
-        self.assertEqual(['traceback', 'traceback-1'], sorted(details))
-        self.assertThat(
+        self.assertEqual(
+            ['broken', 'foo_content', 'traceback', 'traceback-1'],
+            sorted(details))
+        self.expectThat(
+            ''.join(details['broken'].iter_text()),
+            Equals('foobar'))
+        self.expectThat(
+            ''.join(details['foo_content'].iter_text()),
+            Equals('foo ok'))
+        self.expectThat(
             ''.join(details['traceback'].iter_text()),
             Contains('_setUp broke'))
-        self.assertThat(
+        self.expectThat(
             ''.join(details['traceback-1'].iter_text()),
             Contains('foobar'))
 


### PR DESCRIPTION
Previously, when gathering details caused by a setUp failure,
a traceback occurred if the fixture used the newer _setUp().
This also had the side effect of not clearing up fixtures properly.

Fixes: https://bugs.launchpad.net/testtools/+bug/1469759

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/167)
<!-- Reviewable:end -->
