### PR TITLE
Latest Twisted doesn't run on Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ matrix:
   include:
     - python: "2.6"
       env: TWISTED_REQ="Twisted==13.0.0"
-    - python: "2.6"
-      env: TWISTED_REQ="Twisted"
     - python: "2.7"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "2.6"
       # Last version that supports Python 2.6.
-      env: TWISTED_REQ="Twisted==15.5.0"
+      env: TWISTED_REQ="Twisted==15.4.0"
     - python: "2.7"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
   include:
     - python: "2.6"
       env: TWISTED_REQ="Twisted==13.0.0"
+    - python: "2.6"
+      # Last version that supports Python 2.6.
+      env: TWISTED_REQ="Twisted==15.5.0"
     - python: "2.7"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "2.7"


### PR DESCRIPTION
Travis tests are failing because the latest Twisted doesn't support Python 2.6. This removes such tests from our .travis.yml.

I don't _think_ this change is NEWS-worthy, but could be convinced otherwise.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/170)
<!-- Reviewable:end -->
