### PR TITLE
Decouple Twisted logging inside AsynchronousDeferredRunTest

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,7 +10,9 @@ Changes
 -------
 
 * Add a new test dependency of testscenarios. (Robert Collins)
-  
+* Make ``fixtures`` a real dependency, not just a test dependency.
+  (Jonathan Lange)
+
 1.8.1
 ~~~~~
 

--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,8 @@ Changes
 * Add a new test dependency of testscenarios. (Robert Collins)
 * Make ``fixtures`` a real dependency, not just a test dependency.
   (Jonathan Lange)
+* ``testtools.deferredruntest.run_with_log_observers`` is deprecated.
+  (Jonathan Lange)
 
 1.8.1
 ~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyrsistent
 python-mimeparse
 unittest2>=1.0.0
 traceback2
+fixtures

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyrsistent
 python-mimeparse
 unittest2>=1.0.0
 traceback2
-fixtures
+fixtures>=1.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifier =
 
 [extras]
 test =
-  fixtures
   testscenarios
   unittest2>=1.1.0
 

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -154,7 +154,8 @@ class _CaptureTwistedLogs(Fixture):
         logs = StringIO()
         full_observer = log.FileLogObserver(logs)
         self.useFixture(_TwistedLogObservers([full_observer.emit]))
-        self.addDetail(self.LOG_DETAIL_NAME, Content(UTF8_TEXT, logs.getvalue))
+        self.addDetail(self.LOG_DETAIL_NAME,
+                       Content(UTF8_TEXT, lambda: [logs.getvalue()]))
 
 
 def run_with_log_observers(observers, function, *args, **kwargs):
@@ -174,7 +175,8 @@ def run_with_log_observers(observers, function, *args, **kwargs):
 _log_observer = _LogObserver()
 
 
-# XXX: Should really be in python-fixtures
+# XXX: Should really be in python-fixtures.
+# See https://github.com/testing-cabal/fixtures/pull/22.
 class _CompoundFixture(Fixture):
     """A fixture that combines many fixtures."""
 
@@ -384,6 +386,8 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
 
         # We can't just install these as fixtures on self.case, because we
         # need the clean up to run even if the test times out.
+        #
+        # See https://bugs.launchpad.net/testtools/+bug/897196.
         with logging_fixture as capture_logs:
             for name, detail in capture_logs.getDetails().items():
                 self.case.addDetail(name, detail)

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -101,16 +101,25 @@ class NoTwistedLogObservers(Fixture):
         self.addCleanup(_add_observers, publisher, real_observers)
 
 
+class TwistedLogObservers(Fixture):
+    """Temporarily add Twisted log observers."""
+
+    def __init__(self, observers):
+        super(TwistedLogObservers, self).__init__()
+        self._observers = observers
+        self._log_publisher = log.theLogPublisher
+
+    def _setUp(self):
+        for observer in self._observers:
+            self._log_publisher.addObserver(observer)
+            self.addCleanup(self._log_publisher.removeObserver, observer)
+
+
 def run_with_log_observers(observers, function, *args, **kwargs):
     """Run 'function' with the given Twisted log observers."""
     with NoTwistedLogObservers():
-        for observer in observers:
-            log.theLogPublisher.addObserver(observer)
-        try:
+        with TwistedLogObservers(observers):
             return function(*args, **kwargs)
-        finally:
-            for observer in observers:
-                log.theLogPublisher.removeObserver(observer)
 
 
 # Observer of the Twisted log that we install during tests.

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -13,6 +13,7 @@ __all__ = [
     'SynchronousDeferredRunTest',
     ]
 
+import warnings
 import sys
 
 from fixtures import Fixture
@@ -176,7 +177,9 @@ class _CaptureTwistedLogs(Fixture):
 
 def run_with_log_observers(observers, function, *args, **kwargs):
     """Run 'function' with the given Twisted log observers."""
-    # XXX: DEPRECATE THIS
+    warnings.warn(
+        'run_with_log_observers is deprecated since 1.8.2.',
+        DeprecationWarning, stacklevel=2)
     with _NoTwistedLogObservers():
         with _TwistedLogObservers(observers):
             return function(*args, **kwargs)

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -350,7 +350,6 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
         self.case.reactor = self._reactor
         spinner = self._make_spinner()
 
-        # XXX: jml: Review test coverage to see if this is sane.
         with NoTwistedLogObservers():
             # XXX: Would be nice if we could do
             # self.case.useFixture(CaptureTwistedLogs()) here, but

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -161,8 +161,7 @@ class _CaptureTwistedLogs(Fixture):
         # XXX: This isn't actually *useful* yet because Fixture clears details
         # when it exits a context manager (which is the only way we currently
         # use it).
-        self.addCleanup(
-            self.addDetail, self.LOG_DETAIL_NAME, self.get_twisted_log())
+        self.addDetail(self.LOG_DETAIL_NAME, self.get_twisted_log())
 
     def get_twisted_log(self):
         """Return the contents of the Twisted log."""

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -97,9 +97,6 @@ def _remove_observers(publisher, observers):
 class _NoTwistedLogObservers(Fixture):
     """Completely but temporarily remove all Twisted log observers."""
 
-    # XXX: Direct tests. Currently tested indirectly via
-    # run_with_log_observers.
-
     def _setUp(self):
         publisher, real_observers = _get_global_publisher_and_observers()
         _remove_observers(publisher, real_observers)

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -109,23 +109,14 @@ class _TwistedLogObservers(Fixture):
 
 
 class _ErrorObserver(Fixture):
-    """Capture logged errors.
-
-    :ivar logged_errors: list of errors caught while fixture active.
-    """
+    """Capture errors logged while fixture is active."""
 
     def __init__(self, error_observer):
         super(_ErrorObserver, self).__init__()
         self._error_observer = error_observer
-        self.logged_errors = []
 
     def _setUp(self):
-        self.logged_errors = []
         self.useFixture(_TwistedLogObservers([self._error_observer.gotEvent]))
-        self.addCleanup(self._store_logged_errors)
-
-    def _store_logged_errors(self):
-        self.logged_errors = self.flush_logged_errors()
 
     def flush_logged_errors(self, *error_types):
         """Clear errors of the given types from the logs.
@@ -335,7 +326,7 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
         with _ErrorObserver(_log_observer) as error_fixture:
             successful, unhandled = self._blocking_run_deferred(
                 spinner)
-        for logged_error in error_fixture.logged_errors:
+        for logged_error in error_fixture.flush_logged_errors():
             successful = False
             self._got_user_failure(logged_error, tb_label='logged-error')
 

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -138,9 +138,16 @@ class ErrorObserver(Fixture):
         self.addCleanup(self._store_logged_errors)
 
     def _store_logged_errors(self):
-        self.logged_errors = self._error_observer.flushErrors()
+        self.logged_errors = self.flush_logged_errors()
 
-    # XXX: Add flush_logged errors
+    def flush_logged_errors(self, *error_types):
+        """Clear errors of the given types from the logs.
+
+        If no errors provided, clear all errors.
+
+        :return: An iterable of errors removed from the logs.
+        """
+        return self._error_observer.flushErrors(*error_types)
 
 
 def run_with_log_observers(observers, function, *args, **kwargs):
@@ -157,6 +164,14 @@ def run_with_log_observers(observers, function, *args, **kwargs):
 # test cases.
 _log_observer = _LogObserver()
 
+
+def flush_logged_errors(*error_types):
+    # XXX: I would like to deprecate this in favour of
+    # ErrorObserver.flush_logged_errors so that I can avoid mutable global
+    # state. However, I don't know how to make the correct instance of
+    # ErrorObserver.flush_logged_errors available to the end user. I also
+    # don't yet have a clear deprecation/migration path.
+    return _log_observer.flushErrors(*error_types)
 
 
 class AsynchronousDeferredRunTest(_DeferredRunTest):
@@ -404,10 +419,6 @@ def assert_fails_with(d, *exc_types, **kwargs):
         raise failureException("%s raised instead of %s:\n %s" % (
             failure.type.__name__, expected_names, failure.getTraceback()))
     return d.addCallbacks(got_success, got_failure)
-
-
-def flush_logged_errors(*error_types):
-    return _log_observer.flushErrors(*error_types)
 
 
 class UncleanReactorError(Exception):

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -84,23 +84,14 @@ def _get_global_publisher_and_observers():
         return (publisher, list(publisher.observers))
 
 
-def _add_observers(publisher, observers):
-    for observer in observers:
-        publisher.addObserver(observer)
-
-
-def _remove_observers(publisher, observers):
-    for observer in observers:
-        publisher.removeObserver(observer)
-
-
 class _NoTwistedLogObservers(Fixture):
     """Completely but temporarily remove all Twisted log observers."""
 
     def _setUp(self):
         publisher, real_observers = _get_global_publisher_and_observers()
-        _remove_observers(publisher, real_observers)
-        self.addCleanup(_add_observers, publisher, real_observers)
+        for observer in reversed(real_observers):
+            publisher.removeObserver(observer)
+            self.addCleanup(publisher.addObserver, observer)
 
 
 class _TwistedLogObservers(Fixture):
@@ -112,9 +103,9 @@ class _TwistedLogObservers(Fixture):
         self._log_publisher = log.theLogPublisher
 
     def _setUp(self):
-        _add_observers(self._log_publisher, self._observers)
-        self.addCleanup(
-            _remove_observers, self._log_publisher, self._observers)
+        for observer in self._observers:
+            self._log_publisher.addObserver(observer)
+            self.addCleanup(self._log_publisher.removeObserver, observer)
 
 
 class _ErrorObserver(Fixture):

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -112,9 +112,9 @@ class _TwistedLogObservers(Fixture):
         self._log_publisher = log.theLogPublisher
 
     def _setUp(self):
-        for observer in self._observers:
-            self._log_publisher.addObserver(observer)
-            self.addCleanup(self._log_publisher.removeObserver, observer)
+        _add_observers(self._log_publisher, self._observers)
+        self.addCleanup(
+            _remove_observers, self._log_publisher, self._observers)
 
 
 class _ErrorObserver(Fixture):
@@ -346,8 +346,7 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
                 spinner)
         for logged_error in error_fixture.logged_errors:
             successful = False
-            self._got_user_failure(
-                logged_error, tb_label='logged-error')
+            self._got_user_failure(logged_error, tb_label='logged-error')
 
         if unhandled:
             successful = False

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -336,17 +336,18 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
         self.case.reactor = self._reactor
         spinner = self._make_spinner()
 
-        with _NoTwistedLogObservers():
-            self.case.useFixture(_CaptureTwistedLogs())
+        # XXX: We want to make the use of these two fixtures optional, and
+        # ideally, make it so they aren't used by default.
+        self.case.useFixture(_NoTwistedLogObservers())
+        self.case.useFixture(_CaptureTwistedLogs())
 
-            with _ErrorObserver(_log_observer) as error_fixture:
-                successful, unhandled = self._blocking_run_deferred(
-                    spinner)
-
-            for logged_error in error_fixture.logged_errors:
-                successful = False
-                self._got_user_failure(
-                    logged_error, tb_label='logged-error')
+        with _ErrorObserver(_log_observer) as error_fixture:
+            successful, unhandled = self._blocking_run_deferred(
+                spinner)
+        for logged_error in error_fixture.logged_errors:
+            successful = False
+            self._got_user_failure(
+                logged_error, tb_label='logged-error')
 
         if unhandled:
             successful = False

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -106,9 +106,6 @@ class _NoTwistedLogObservers(Fixture):
 class _TwistedLogObservers(Fixture):
     """Temporarily add Twisted log observers."""
 
-    # XXX: Direct tests. Currently tested indirectly via
-    # run_with_log_observers.
-
     def __init__(self, observers):
         super(_TwistedLogObservers, self).__init__()
         self._observers = observers

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -1158,7 +1158,7 @@ class TextTestResult(TestResult):
         self.stream.write(
             "\nRan %d test%s in %.3fs\n" % (
                 self.testsRun, plural,
-                self._delta_to_float(stop - self.__start, 4)))
+                self._delta_to_float(stop - self.__start, 3)))
         if self.wasSuccessful():
             self.stream.write("OK\n")
         else:

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -1158,7 +1158,7 @@ class TextTestResult(TestResult):
         self.stream.write(
             "\nRan %d test%s in %.3fs\n" % (
                 self.testsRun, plural,
-                self._delta_to_float(stop - self.__start, 3)))
+                self._delta_to_float(stop - self.__start, 4)))
         if self.wasSuccessful():
             self.stream.write("OK\n")
         else:

--- a/testtools/tests/test_deferredruntest.py
+++ b/testtools/tests/test_deferredruntest.py
@@ -905,6 +905,28 @@ class TestNoTwistedLogObservers(NeedsTwistedTestCase):
             MatchesListwise([ContainsDict({'message': Equals(('bar',))})]))
 
 
+class TestTwistedLogObservers(NeedsTwistedTestCase):
+    """Tests for _TwistedLogObservers."""
+
+    def test_logged_messages_go_to_observer(self):
+        # Using _TwistedLogObservers means messages logged to Twisted go to
+        # that observer while the fixture is active.
+        from testtools.deferredruntest import _TwistedLogObservers
+
+        messages = []
+
+        class SomeTest(TestCase):
+            def test_something(self):
+                self.useFixture(_TwistedLogObservers([messages.append]))
+                log.msg('foo')
+
+        SomeTest('test_something').run()
+        log.msg('bar')
+        self.assertThat(
+            messages,
+            MatchesListwise([ContainsDict({'message': Equals(('foo',))})]))
+
+
 def test_suite():
     from unittest2 import TestLoader, TestSuite
     return TestLoader().loadTestsFromName(__name__)

--- a/testtools/tests/test_deferredruntest.py
+++ b/testtools/tests/test_deferredruntest.py
@@ -951,7 +951,7 @@ class TestErrorObserver(NeedsTwistedTestCase):
 
         SomeTest('test_something').run()
         self.assertThat(
-            error_observer.logged_errors,
+            error_observer.flush_logged_errors(),
             MatchesListwise([
                 AfterPreprocessing(lambda x: x.value, Equals(exception))]))
 

--- a/testtools/tests/test_deferredruntest.py
+++ b/testtools/tests/test_deferredruntest.py
@@ -14,6 +14,7 @@ from testtools import (
     )
 from testtools.matchers import (
     AfterPreprocessing,
+    Contains,
     ContainsAll,
     ContainsDict,
     EndsWith,
@@ -954,6 +955,26 @@ class TestErrorObserver(NeedsTwistedTestCase):
             MatchesListwise([
                 AfterPreprocessing(lambda x: x.value, Equals(exception))]))
 
+
+class TestCaptureTwistedLogs(NeedsTwistedTestCase):
+    """Tests for _CaptureTwistedLogs."""
+
+    def test_captures_logs(self):
+        # _CaptureTwistedLogs stores all Twisted log messages as a detail.
+        from testtools.deferredruntest import _CaptureTwistedLogs
+
+        class SomeTest(TestCase):
+            def test_something(self):
+                self.useFixture(_CaptureTwistedLogs())
+                log.msg('foo')
+
+        test = SomeTest('test_something')
+        test.run()
+        self.assertThat(
+            test.getDetails(),
+            MatchesDict({
+                'twisted-log': AsText(Contains('foo')),
+            }))
 
 
 def test_suite():

--- a/testtools/tests/test_deferredruntest.py
+++ b/testtools/tests/test_deferredruntest.py
@@ -711,6 +711,7 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
         messages = []
         publisher, _ = _get_global_publisher_and_observers()
         publisher.addObserver(messages.append)
+        self.addCleanup(publisher.removeObserver, messages.append)
 
         class LogSomething(TestCase):
             def test_something(self):
@@ -721,6 +722,36 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
         result = self.make_result()
         runner.run(result)
         self.assertThat(messages, Equals([]))
+
+    def test_restore_observers(self):
+        # We restore the original observers.
+        publisher, observers = _get_global_publisher_and_observers()
+
+        class LogSomething(TestCase):
+            def test_something(self):
+                pass
+
+        test = LogSomething('test_something')
+        runner = self.make_runner(test)
+        result = self.make_result()
+        runner.run(result)
+        self.assertThat(
+            _get_global_publisher_and_observers()[1], Equals(observers))
+
+    def test_restore_observers_after_timeout(self):
+        # We restore the original observers even if the test times out.
+        publisher, observers = _get_global_publisher_and_observers()
+
+        class LogSomething(TestCase):
+            def test_something(self):
+                return defer.Deferred()
+
+        test = LogSomething('test_something')
+        runner = self.make_runner(test, timeout=0.0001)
+        result = self.make_result()
+        runner.run(result)
+        self.assertThat(
+            _get_global_publisher_and_observers()[1], Equals(observers))
 
     def test_debugging_unchanged_during_test_by_default(self):
         debugging = [(defer.Deferred.debug, DelayedCall.debug)]


### PR DESCRIPTION
This patch works towards fixes for https://pad.lv/942785 and https://pad.lv/1515362. I believe it makes no behavioral changes and introduces no new APIs.

On IRC, @rbtcollins suggest that `AsynchronousDeferredRunTest` was conflating responsibilities: taking over the Twisted logs in addition to being responsible for spinning the reactor and gathering errors. 

This patch begins to untangle these responsibilities. It deprecates `run_with_log_observers` and ceases to use it. The functionality of `run_with_log_observers` is split into two Fixtures: `_NoTwistedLogObservers` (removes all log observers) and `_TwistedLogObservers` (adds some log observers).

It then provides two new specialized fixtures: `_CaptureTwistedLogs` (stores all Twisted logs as a detail) and `_ErrorObserver` (records all `log.err` calls—necessary for preserving expected behavior in Twisted tests). These fixtures are then used in `AsynchronousDeferredRunTest` to provide the same functionality that we provided before. 

My intent is that a follow-up patch would add parameters to `AsynchronousDeferredRunTest` to disable the use of `_NoTwistedLogObservers` and `_CaptureTwistedLogs`, and perhaps also expose the two fixtures at the same time. This would allow users to work around lp:942785 and lp:1515362. 

My big qualm about this patch is that it makes [fixtures](https://github.com/testing-cabal/fixtures) a dependency. Since testtools is a dependency of fixtures, this gives us a circular dependency. I think the "correct" fix is actually to move the entire `deferredruntest` option to a separate Python package (perhaps `txtesttools`), but even then, I don't know how we'd manage the deprecation smoothly. I welcome suggestions.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/171)
<!-- Reviewable:end -->
