### PR TITLE
Better error message for MatchesListwise

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,12 @@ Changes and improvements to testtools_, grouped by release.
 Next
 ~~~~
 
+Improvements
+------------
+
+* ``MatchesListwise`` has more informative error when lengths don't match.
+  (Jonathan Lange)
+
 Changes
 -------
 

--- a/testtools/matchers/_datastructures.py
+++ b/testtools/matchers/_datastructures.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2009-2015 testtools developers. See LICENSE for details.
 
 __all__ = [
     'ContainsAll',
@@ -58,10 +58,10 @@ class MatchesListwise(object):
         self.first_only = first_only
 
     def match(self, values):
-        from ._basic import Equals
+        from ._basic import HasLength
         mismatches = []
         length_mismatch = Annotate(
-            "Length mismatch", Equals(len(self.matchers))).match(len(values))
+            "Length mismatch", HasLength(len(self.matchers))).match(values)
         if length_mismatch:
             mismatches.append(length_mismatch)
         for matcher, value in zip(self.matchers, values):


### PR DESCRIPTION
Given this code:

```python
from testtools import TestCase
from testtools.matchers import Equals, MatchesListwise


class FooTests(TestCase):

    def test_foo(self):
        self.assertThat([1], MatchesListwise([Equals(1), Equals(2)]))


def test_suite():
    return FooTests('test_foo')
```

On master, we would get this result:

```
$ python -m testtools.run example.test_suite
Tests running...
======================================================================
FAIL: example.FooTests.test_foo
----------------------------------------------------------------------
Traceback (most recent call last):
  File "example.py", line 8, in test_foo
    self.assertThat([1], MatchesListwise([Equals(1), Equals(2)]))
  File "testtools/testcase.py", line 435, in assertThat
    raise mismatch_error
testtools.matchers._impl.MismatchError: Differences: [
len([1]) != 2: Length mismatch
]

Ran 1 test in 0.002s
FAILED (failures=1)
```

This result doesn't communicate anything about the object being matched.

This patch changes `MatchesListwise` to use `HasLength` for its length matching, which turns the error into:

```
$ python -m testtools.run example.test_suite
Tests running...
======================================================================
FAIL: example.FooTests.test_foo
----------------------------------------------------------------------
Traceback (most recent call last):
  File "example.py", line 8, in test_foo
    self.assertThat([1], MatchesListwise([Equals(1), Equals(2)]))
  File "testtools/testcase.py", line 435, in assertThat
    raise mismatch_error
testtools.matchers._impl.MismatchError: Differences: [
len([1]) != 2: Length mismatch
]

Ran 1 test in 0.001s
FAILED (failures=1)
```

Note that the traceback now includes the item being matched (`[1]`).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/173)
<!-- Reviewable:end -->
