### PR TITLE
Expose & document deferredruntest

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -19,6 +19,13 @@ testtools
    :members:
 
 
+testtools.deferredruntest
+-------------------------
+
+.. automodule:: testtools.deferredruntest
+   :members:
+
+
 testtools.matchers
 ------------------
 

--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -1437,6 +1437,7 @@ Here, ``repr(nullary)`` will be the same as ``repr(f)``.
 .. _fixtures: http://pypi.python.org/pypi/fixtures
 .. _unittest: http://docs.python.org/library/unittest.html
 .. _doctest: http://docs.python.org/library/doctest.html
+.. _Deferred: http://twistedmatrix.com/documents/current/core/howto/defer.html
 .. _discover: http://pypi.python.org/pypi/discover
 .. _Distutils: http://docs.python.org/library/distutils.html
 .. _`setup configuration`: http://docs.python.org/distutils/configfile.html

--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -1253,51 +1253,8 @@ in case it is needed.
 Twisted support
 ---------------
 
-testtools provides *highly experimental* support for running Twisted tests –
-tests that return a Deferred_ and rely on the Twisted reactor.  You should not
-use this feature right now.  We reserve the right to change the API and
-behaviour without telling you first.
-
-However, if you are going to, here's how you do it::
-
-  from testtools import TestCase
-  from testtools.deferredruntest import AsynchronousDeferredRunTest
-
-  class MyTwistedTests(TestCase):
-
-      run_tests_with = AsynchronousDeferredRunTest
-
-      def test_foo(self):
-          # ...
-          return d
-
-In particular, note that you do *not* have to use a special base ``TestCase``
-in order to run Twisted tests.
-
-You can also run individual tests within a test case class using the Twisted
-test runner::
-
-   class MyTestsSomeOfWhichAreTwisted(TestCase):
-
-       def test_normal(self):
-           pass
-
-       @run_test_with(AsynchronousDeferredRunTest)
-       def test_twisted(self):
-           # ...
-           return d
-
-Here are some tips for converting your Trial tests into testtools tests.
-
-* Use the ``AsynchronousDeferredRunTest`` runner
-* Make sure to upcall to ``setUp`` and ``tearDown``
-* Don't use ``setUpClass`` or ``tearDownClass``
-* Don't expect setting .todo, .timeout or .skip attributes to do anything
-* ``flushLoggedErrors`` is ``testtools.deferredruntest.flush_logged_errors``
-* ``assertFailure`` is ``testtools.deferredruntest.assert_fails_with``
-* Trial spins the reactor a couple of times before cleaning it up,
-  ``AsynchronousDeferredRunTest`` does not.  If you rely on this behavior, use
-  ``AsynchronousDeferredRunTestForBrokenTwisted``.
+testtools provides support for running Twisted tests – tests that return a
+Deferred_ and rely on the Twisted reactor. See (XXX - jml - insert link)
 
 force_failure
 -------------
@@ -1480,7 +1437,6 @@ Here, ``repr(nullary)`` will be the same as ``repr(f)``.
 .. _fixtures: http://pypi.python.org/pypi/fixtures
 .. _unittest: http://docs.python.org/library/unittest.html
 .. _doctest: http://docs.python.org/library/doctest.html
-.. _Deferred: http://twistedmatrix.com/documents/current/core/howto/defer.html
 .. _discover: http://pypi.python.org/pypi/discover
 .. _Distutils: http://docs.python.org/library/distutils.html
 .. _`setup configuration`: http://docs.python.org/distutils/configfile.html

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -23,6 +23,7 @@ Contents:
    overview
    for-test-authors
    for-framework-folk
+   twisted-support
    hacking
    Changes to testtools <news>
    API reference documentation <api>

--- a/doc/twisted-support.rst
+++ b/doc/twisted-support.rst
@@ -1,0 +1,52 @@
+Twisted support
+===============
+
+testtools provides support for running Twisted tests – tests that return a
+Deferred_ and rely on the Twisted reactor.
+
+You should not use this feature right now. We reserve the right to change the
+API and behaviour without telling you first.
+
+However, if you are going to, here's how you do it::
+
+  from testtools import TestCase
+  from testtools.deferredruntest import AsynchronousDeferredRunTest
+
+  class MyTwistedTests(TestCase):
+
+      run_tests_with = AsynchronousDeferredRunTest
+
+      def test_foo(self):
+          # ...
+          return d
+
+In particular, note that you do *not* have to use a special base ``TestCase``
+in order to run Twisted tests.
+
+You can also run individual tests within a test case class using the Twisted
+test runner::
+
+   class MyTestsSomeOfWhichAreTwisted(TestCase):
+
+       def test_normal(self):
+           pass
+
+       @run_test_with(AsynchronousDeferredRunTest)
+       def test_twisted(self):
+           # ...
+           return d
+
+Here are some tips for converting your Trial tests into testtools tests.
+
+* Use the ``AsynchronousDeferredRunTest`` runner
+* Make sure to upcall to ``setUp`` and ``tearDown``
+* Don't use ``setUpClass`` or ``tearDownClass``
+* Don't expect setting .todo, .timeout or .skip attributes to do anything
+* ``flushLoggedErrors`` is ``testtools.deferredruntest.flush_logged_errors``
+* ``assertFailure`` is ``testtools.deferredruntest.assert_fails_with``
+* Trial spins the reactor a couple of times before cleaning it up,
+  ``AsynchronousDeferredRunTest`` does not.  If you rely on this behavior, use
+  ``AsynchronousDeferredRunTestForBrokenTwisted``.
+
+
+.. _Deferred: http://twistedmatrix.com/documents/current/core/howto/defer.html

--- a/doc/twisted-support.rst
+++ b/doc/twisted-support.rst
@@ -4,10 +4,7 @@ Twisted support
 testtools provides support for running Twisted tests – tests that return a
 Deferred_ and rely on the Twisted reactor.
 
-You should not use this feature right now. We reserve the right to change the
-API and behaviour without telling you first.
-
-However, if you are going to, here's how you do it::
+Here's how to use it::
 
   from testtools import TestCase
   from testtools.deferredruntest import AsynchronousDeferredRunTest
@@ -20,8 +17,9 @@ However, if you are going to, here's how you do it::
           # ...
           return d
 
-In particular, note that you do *not* have to use a special base ``TestCase``
-in order to run Twisted tests.
+Note that you do *not* have to use a special base ``TestCase`` in order to run
+Twisted tests, you should just use the regular ``testtools.TestCase`` base
+class.
 
 You can also run individual tests within a test case class using the Twisted
 test runner::
@@ -36,7 +34,9 @@ test runner::
            # ...
            return d
 
-Here are some tips for converting your Trial tests into testtools tests.
+
+Converting Trial tests to testtools tests
+-----------------------------------------
 
 * Use the ``AsynchronousDeferredRunTest`` runner
 * Make sure to upcall to ``setUp`` and ``tearDown``

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -1,12 +1,29 @@
 # Copyright (c) 2010 testtools developers. See LICENSE for details.
 
-"""Individual test case execution for tests that return Deferreds."""
+"""Individual test case execution for tests that return Deferreds.
+
+Example::
+
+    class TwistedTests(testtools.TestCase):
+
+        run_tests_with = AsynchronousDeferredRunTest
+
+        def test_something(self):
+            # Wait for 5 seconds and then fire with 'Foo'.
+            d = Deferred()
+            reactor.callLater(5, lambda: d.callback('Foo'))
+            d.addCallback(self.assertEqual, 'Foo')
+            return d
+
+When ``test_something`` is run, ``AsynchronousDeferredRunTest`` will run the
+reactor until ``d`` fires, and wait for all of its callbacks to be processed.
+"""
 
 __all__ = [
-    'assert_fails_with',
     'AsynchronousDeferredRunTest',
     'AsynchronousDeferredRunTestForBrokenTwisted',
     'SynchronousDeferredRunTest',
+    'assert_fails_with',
     ]
 
 import sys
@@ -45,7 +62,11 @@ class _DeferredRunTest(RunTest):
 
 
 class SynchronousDeferredRunTest(_DeferredRunTest):
-    """Runner for tests that return synchronous Deferreds."""
+    """Runner for tests that return synchronous Deferreds.
+
+    This runner doesn't touch the reactor at all. It assumes that tests return
+    Deferreds that have already fired.
+    """
 
     def _run_user(self, function, *args):
         d = defer.maybeDeferred(function, *args)
@@ -89,8 +110,8 @@ _log_observer = _LogObserver()
 class AsynchronousDeferredRunTest(_DeferredRunTest):
     """Runner for tests that return Deferreds that fire asynchronously.
 
-    Use this runner when you have tests that return Deferreds that will only
-    fire if the reactor is left to spin for a while.
+    Use this runner when you have tests that return Deferreds that will
+    only fire if the reactor is left to spin for a while.
     """
 
     def __init__(self, case, handlers=None, last_resort=None, reactor=None,
@@ -102,7 +123,7 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
         compatibility with that we have to insert them before the local
         parameters.
 
-        :param case: The `TestCase` to run.
+        :param TestCase case: The `TestCase` to run.
         :param handlers: A list of exception handlers (ExceptionType, handler)
             where 'handler' is a callable that takes a `TestCase`, a
             ``testtools.TestResult`` and the exception raised.
@@ -110,7 +131,7 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
             exceptions (those for which there is no handler).
         :param reactor: The Twisted reactor to use.  If not given, we use the
             default reactor.
-        :param timeout: The maximum time allowed for running a test.  The
+        :param float timeout: The maximum time allowed for running a test.  The
             default is 0.005s.
         :param debug: Whether or not to enable Twisted's debugging.  Use this
             to get information about unhandled Deferreds and left-over
@@ -126,7 +147,15 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
 
     @classmethod
     def make_factory(cls, reactor=None, timeout=0.005, debug=False):
-        """Make a factory that conforms to the RunTest factory interface."""
+        """Make a factory that conforms to the RunTest factory interface.
+
+        Example::
+
+            class SomeTests(TestCase):
+                # Timeout tests after two minutes.
+                run_tests_with = AsynchronousDeferredRunTest.make_factory(
+                    timeout=120)
+        """
         # This is horrible, but it means that the return value of the method
         # will be able to be assigned to a class variable *and* also be
         # invoked directly.
@@ -293,21 +322,21 @@ class AsynchronousDeferredRunTestForBrokenTwisted(AsynchronousDeferredRunTest):
 
 
 def assert_fails_with(d, *exc_types, **kwargs):
-    """Assert that 'd' will fail with one of 'exc_types'.
+    """Assert that ``d`` will fail with one of ``exc_types``.
 
-    The normal way to use this is to return the result of 'assert_fails_with'
-    from your unit test.
+    The normal way to use this is to return the result of
+    ``assert_fails_with`` from your unit test.
 
     Equivalent to Twisted's ``assertFailure``.
 
-    :param d: A Deferred that is expected to fail.
-    :param exc_types: The exception types that the Deferred is expected to
+    :param Deferred d: A ``Deferred`` that is expected to fail.
+    :param *exc_types: The exception types that the Deferred is expected to
         fail with.
-    :param failureException: An optional keyword argument.  If provided, will
-        raise that exception instead of
+    :param type failureException: An optional keyword argument.  If provided,
+        will raise that exception instead of
         ``testtools.TestCase.failureException``.
-    :return: A Deferred that will fail with an ``AssertionError`` if 'd' does
-        not fail with one of the exception types.
+    :return: A ``Deferred`` that will fail with an ``AssertionError`` if ``d``
+        does not fail with one of the exception types.
     """
     failureException = kwargs.pop('failureException', None)
     if failureException is None:

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -1,10 +1,6 @@
 # Copyright (c) 2010 testtools developers. See LICENSE for details.
 
-"""Individual test case execution for tests that return Deferreds.
-
-This module is highly experimental and is liable to change in ways that cause
-subtle failures in tests.  Use at your own peril.
-"""
+"""Individual test case execution for tests that return Deferreds."""
 
 __all__ = [
     'assert_fails_with',
@@ -90,18 +86,11 @@ def run_with_log_observers(observers, function, *args, **kwargs):
 _log_observer = _LogObserver()
 
 
-
 class AsynchronousDeferredRunTest(_DeferredRunTest):
     """Runner for tests that return Deferreds that fire asynchronously.
 
-    That is, this test runner assumes that the Deferreds will only fire if the
-    reactor is left to spin for a while.
-
-    Do not rely too heavily on the nuances of the behaviour of this class.
-    What it does to the reactor is black magic, and if we can find nicer ways
-    of doing it we will gladly break backwards compatibility.
-
-    This is highly experimental code.  Use at your own risk.
+    Use this runner when you have tests that return Deferreds that will only
+    fire if the reactor is left to spin for a while.
     """
 
     def __init__(self, case, handlers=None, last_resort=None, reactor=None,
@@ -143,7 +132,8 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
         # invoked directly.
         class AsynchronousDeferredRunTestFactory:
             def __call__(self, case, handlers=None, last_resort=None):
-                return cls(case, handlers, last_resort, reactor, timeout, debug)
+                return cls(
+                    case, handlers, last_resort, reactor, timeout, debug)
         return AsynchronousDeferredRunTestFactory()
 
     @defer.deferredGenerator
@@ -188,6 +178,7 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
         def clean_up(ignored=None):
             """Run the cleanups."""
             d = self._run_cleanups()
+
             def clean_up_done(result):
                 if result is not None:
                     self._exceptions.append(result)
@@ -307,8 +298,7 @@ def assert_fails_with(d, *exc_types, **kwargs):
     The normal way to use this is to return the result of 'assert_fails_with'
     from your unit test.
 
-    Note that this function is experimental and unstable.  Use at your own
-    peril; expect the API to change.
+    Equivalent to Twisted's ``assertFailure``.
 
     :param d: A Deferred that is expected to fail.
     :param exc_types: The exception types that the Deferred is expected to
@@ -325,9 +315,11 @@ def assert_fails_with(d, *exc_types, **kwargs):
         from testtools import TestCase
         failureException = TestCase.failureException
     expected_names = ", ".join(exc_type.__name__ for exc_type in exc_types)
+
     def got_success(result):
         raise failureException(
             "%s not raised (%r returned)" % (expected_names, result))
+
     def got_failure(failure):
         if failure.check(*exc_types):
             return failure.value
@@ -344,7 +336,8 @@ class UncleanReactorError(Exception):
     """Raised when the reactor has junk in it."""
 
     def __init__(self, junk):
-        Exception.__init__(self,
+        Exception.__init__(
+            self,
             "The reactor still thinks it needs to do things. Close all "
             "connections, kill all processes and make sure all delayed "
             "calls have either fired or been cancelled:\n%s"


### PR DESCRIPTION
Removes the scare warnings from deferredruntest and prose docs. Moves the prose docs to a separate file. Updates the API documentation a little.

Fixes https://bugs.launchpad.net/testtools/+bug/1515684

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/174)
<!-- Reviewable:end -->
