### PR TITLE
Add getUniqueText creation method to TestCase

### DIFF
--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -1346,9 +1346,9 @@ fine.  However, sometimes it's useful to be able to create arbitrary objects
 at will, without having to make up silly sample data.
 
 To help with this, ``testtools.TestCase`` implements creation methods called
-``getUniqueString`` and ``getUniqueInteger``.  They return strings and
-integers that are unique within the context of the test that can be used to
-assemble more complex objects.  Here's a basic example where
+``getUniqueString``, ``getUniqueInteger``, and ``getUniqueText``.  They return
+strings and integers that are unique within the context of the test that can be
+used to assemble more complex objects.  Here's a basic example where
 ``getUniqueString`` is used instead of saying "foo" or "bar" or whatever::
 
   class SomeTest(TestCase):
@@ -1384,6 +1384,10 @@ details of certain variables don't actually matter.
 
 See pages 419-423 of `xUnit Test Patterns`_ by Gerard Meszaros for a detailed
 discussion of creation methods.
+
+``getUniqueText`` is similar to ``getUniqueString``, except it generates text
+that contains unicode characters. As such the value will be a unicode string
+in Python2 and a str in Python3.
 
 Test attributes
 ---------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyrsistent
 python-mimeparse
 unittest2>=1.0.0
 traceback2
+six

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -21,6 +21,8 @@ import itertools
 import sys
 import types
 
+import six
+
 from extras import (
     safe_hasattr,
     try_import,
@@ -545,6 +547,22 @@ class TestCase(unittest.TestCase):
         if prefix is None:
             prefix = self.id()
         return '%s-%d' % (prefix, self.getUniqueInteger())
+
+    def getUniqueText(self, prefix=None):
+        """Generate text unique to this test.
+
+        Returns text that is guaranteed to be unique to this instance. Use
+        this when you need arbitrary text in your test, or as a helper
+        for custom anonymous factory methods.
+
+        :param prefix: The prefix of the string. If not provided, defaults
+            to the id of the test.
+        :return: text that looks like '<prefix>-<text_with_unicode>'.
+        :rtype: six.text_type
+        """
+        if prefix is None:
+            prefix = self.id()
+        return six.text_type('%s-%s') % (prefix, six.unichr(0x1e00))
 
     def onException(self, exc_info, tb_label='traceback'):
         """Called when an exception propogates from test code.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -562,7 +562,8 @@ class TestCase(unittest.TestCase):
         """
         if prefix is None:
             prefix = self.id()
-        return six.text_type('%s-%s') % (prefix, six.unichr(0x1e00))
+        unique_text = six.unichr(0x1e00 + self.getUniqueInteger() - 1)
+        return six.text_type('%s-%s') % (prefix, unique_text)
 
     def onException(self, exc_info, tb_label='traceback'):
         """Called when an exception propogates from test code.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -581,9 +581,12 @@ class TestCase(unittest.TestCase):
 
         # 0x1e00 is the start of a range of chars that are easy to see are
         # unicode since they've got circles and dots and other diacriticals.
+        # 0x1eff is the end of the range of these diacritical chars.
         BASE_CP = 0x1e00
+        CP_RANGE = 0x1f00 - BASE_CP
 
-        unique_text = six.unichr(BASE_CP + self.getUniqueInteger() - 1)
+        unique_text = _unique_text(BASE_CP, CP_RANGE,
+                                   self.getUniqueInteger() - 1)
         return six.text_type('%s-%s') % (prefix, unique_text)
 
     def onException(self, exc_info, tb_label='traceback'):

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -562,7 +562,12 @@ class TestCase(unittest.TestCase):
         """
         if prefix is None:
             prefix = self.id()
-        unique_text = six.unichr(0x1e00 + self.getUniqueInteger() - 1)
+
+        # 0x1e00 is the start of a range of chars that are easy to see are
+        # unicode since they've got circles and dots and other diacriticals.
+        BASE_CP = 0x1e00
+
+        unique_text = six.unichr(BASE_CP + self.getUniqueInteger() - 1)
         return six.text_type('%s-%s') % (prefix, unique_text)
 
     def onException(self, exc_info, tb_label='traceback'):

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -565,11 +565,11 @@ class TestCase(unittest.TestCase):
         return '%s-%d' % (prefix, self.getUniqueInteger())
 
     def getUniqueText(self, prefix=None):
-        """Generate text unique to this test.
+        """Generate a text value unique to this test and invocation.
 
-        Returns text that is guaranteed to be unique to this instance. Use
-        this when you need arbitrary text in your test, or as a helper
-        for custom anonymous factory methods.
+        Returns a text value that is guaranteed to be unique to this
+        invocation. Use this when you need arbitrary text in your test, or as a
+        helper for custom anonymous factory methods.
 
         :param prefix: The prefix of the string. If not provided, defaults
             to the id of the test.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -175,6 +175,22 @@ def gather_details(source_dict, target_dict):
         target_dict[name] = _copy_content(content_object)
 
 
+def _mods(i, mod):
+    (q, r) = divmod(i, mod)
+    while True:
+        yield r
+        if not q:
+            break
+        (q, r) = divmod(q, mod)
+
+
+def _unique_text(base_cp, cp_range, index):
+    s = six.text_type('')
+    for m in _mods(index, cp_range):
+        s += six.unichr(base_cp + m)
+    return s
+
+
 class TestCase(unittest.TestCase):
     """Extensions to the basic TestCase.
 

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1077,6 +1077,38 @@ class TestUniqueFactories(TestCase):
         self.assertEqual(six.text_type('%s-%s') %
                          (self.id(), u'\u1e01'), second_result)
 
+    def test_mods(self):
+        # given a number and max, generate a list that's the mods.
+        # The list should contain no numbers >= mod
+        self.assertEqual([0], list(testcase._mods(0, 5)))
+        self.assertEqual([1], list(testcase._mods(1, 5)))
+        self.assertEqual([2], list(testcase._mods(2, 5)))
+        self.assertEqual([3], list(testcase._mods(3, 5)))
+        self.assertEqual([4], list(testcase._mods(4, 5)))
+        self.assertEqual([0, 1], list(testcase._mods(5, 5)))
+        self.assertEqual([1, 1], list(testcase._mods(6, 5)))
+        self.assertEqual([2, 1], list(testcase._mods(7, 5)))
+        self.assertEqual([0, 2], list(testcase._mods(10, 5)))
+        self.assertEqual([0, 0, 1], list(testcase._mods(25, 5)))
+        self.assertEqual([1, 0, 1], list(testcase._mods(26, 5)))
+        self.assertEqual([1], list(testcase._mods(1, 100)))
+        self.assertEqual([0, 1], list(testcase._mods(100, 100)))
+        self.assertEqual([0, 10], list(testcase._mods(1000, 100)))
+
+    def test_unique_text(self):
+        self.assertEqual(
+            u'\u1e00',
+            testcase._unique_text(base_cp=0x1e00, cp_range=5, index=0))
+        self.assertEqual(
+            u'\u1e01',
+            testcase._unique_text(base_cp=0x1e00, cp_range=5, index=1))
+        self.assertEqual(
+            u'\u1e00\u1e01',
+            testcase._unique_text(base_cp=0x1e00, cp_range=5, index=5))
+        self.assertEqual(
+            u'\u1e03\u1e02\u1e01',
+            testcase._unique_text(base_cp=0x1e00, cp_range=5, index=38))
+
 
 class TestCloneTestWithNewId(TestCase):
     """Tests for clone_test_with_new_id."""

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1069,9 +1069,13 @@ class TestUniqueFactories(TestCase):
     def test_getUniqueText(self):
         # getUniqueText with no prefix returns current test ID followed by
         # a unique unicode character.
-        text_one = self.getUniqueText()
+        first_result = self.getUniqueText()
         self.assertEqual(six.text_type('%s-%s') %
-                         (self.id(), six.unichr(0x1e00)), text_one)
+                         (self.id(), u'\u1e00'), first_result)
+        # You get different text the next time getUniqueText is called.
+        second_result = self.getUniqueText()
+        self.assertEqual(six.text_type('%s-%s') %
+                         (self.id(), u'\u1e01'), second_result)
 
 
 class TestCloneTestWithNewId(TestCase):

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -7,6 +7,8 @@ from pprint import pformat
 import sys
 import unittest
 
+import six
+
 from testtools import (
     DecorateTestCaseResult,
     ErrorHolder,
@@ -1036,7 +1038,7 @@ class TestExpectedFailure(TestWithDetails):
 
 
 class TestUniqueFactories(TestCase):
-    """Tests for getUniqueString and getUniqueInteger."""
+    """Tests for getUniqueString, getUniqueInteger, and getUniqueText."""
 
     run_test_with = FullStackRunTest
 
@@ -1063,6 +1065,13 @@ class TestUniqueFactories(TestCase):
         self.assertThat(name_one, Equals('foo-1'))
         name_two = self.getUniqueString('bar')
         self.assertThat(name_two, Equals('bar-2'))
+
+    def test_getUniqueText(self):
+        # getUniqueText with no prefix returns current test ID followed by
+        # a unique unicode character.
+        text_one = self.getUniqueText()
+        self.assertEqual(six.text_type('%s-%s') %
+                         (self.id(), six.unichr(0x1e00)), text_one)
 
 
 class TestCloneTestWithNewId(TestCase):


### PR DESCRIPTION
This adds a new creation method to TestCase for py2/3 to help application developers test for proper unicode handling.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/175)
<!-- Reviewable:end -->
