### PR TITLE
Add generate_unique_text generator

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,7 +10,11 @@ Changes
 -------
 
 * Add a new test dependency of testscenarios. (Robert Collins)
-  
+
+* Introduce the unique_text_generator generator function. Similar to the
+  getUniqueString() method, except it creates unique unicode text strings.
+  (Brant Knudson)
+
 1.8.1
 ~~~~~
 

--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -1346,9 +1346,9 @@ fine.  However, sometimes it's useful to be able to create arbitrary objects
 at will, without having to make up silly sample data.
 
 To help with this, ``testtools.TestCase`` implements creation methods called
-``getUniqueString``, ``getUniqueInteger``, and ``getUniqueText``.  They return
-strings and integers that are unique within the context of the test that can be
-used to assemble more complex objects.  Here's a basic example where
+``getUniqueString`` and ``getUniqueInteger``.  They return strings and integers
+that are unique within the context of the test that can be used to assemble
+more complex objects.  Here's a basic example where
 ``getUniqueString`` is used instead of saying "foo" or "bar" or whatever::
 
   class SomeTest(TestCase):
@@ -1385,9 +1385,9 @@ details of certain variables don't actually matter.
 See pages 419-423 of `xUnit Test Patterns`_ by Gerard Meszaros for a detailed
 discussion of creation methods.
 
-``getUniqueText`` is similar to ``getUniqueString``, except it generates text
-that contains unicode characters. As such the value will be a unicode string
-in Python2 and a str in Python3.
+``testcase.generate_unique_text()`` is similar to ``getUniqueString``, except
+it generates text that contains unicode characters. As such the value will be a
+unicode string in Python2 and a str in Python3.
 
 Test attributes
 ---------------

--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -1346,9 +1346,9 @@ fine.  However, sometimes it's useful to be able to create arbitrary objects
 at will, without having to make up silly sample data.
 
 To help with this, ``testtools.TestCase`` implements creation methods called
-``getUniqueString`` and ``getUniqueInteger``.  They return strings and integers
-that are unique within the context of the test that can be used to assemble
-more complex objects.  Here's a basic example where
+``getUniqueString`` and ``getUniqueInteger``.  They return strings and
+integers that are unique within the context of the test that can be used to
+assemble more complex objects.  Here's a basic example where
 ``getUniqueString`` is used instead of saying "foo" or "bar" or whatever::
 
   class SomeTest(TestCase):

--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -1346,9 +1346,9 @@ fine.  However, sometimes it's useful to be able to create arbitrary objects
 at will, without having to make up silly sample data.
 
 To help with this, ``testtools.TestCase`` implements creation methods called
-``getUniqueString`` and ``getUniqueInteger``.  They return strings and
-integers that are unique within the context of the test that can be used to
-assemble more complex objects.  Here's a basic example where
+``getUniqueString``, ``getUniqueInteger``, and ``getUniqueText``.  They return
+strings and integers that are unique within the context of the test that can be
+used to assemble more complex objects.  Here's a basic example where
 ``getUniqueString`` is used instead of saying "foo" or "bar" or whatever::
 
   class SomeTest(TestCase):
@@ -1384,6 +1384,10 @@ details of certain variables don't actually matter.
 
 See pages 419-423 of `xUnit Test Patterns`_ by Gerard Meszaros for a detailed
 discussion of creation methods.
+
+``getUniqueText`` is similar to ``getUniqueString``, except it generates text
+that contains unicode characters. As such the value will be a unicode string
+in Python2 and a str in Python3.
 
 Test attributes
 ---------------

--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -1386,8 +1386,8 @@ See pages 419-423 of `xUnit Test Patterns`_ by Gerard Meszaros for a detailed
 discussion of creation methods.
 
 ``testcase.generate_unique_text()`` is similar to ``getUniqueString``, except
-it generates text that contains unicode characters. As such the value will be a
-unicode string in Python2 and a str in Python3.
+it generates text that contains unicode characters. The value will be a
+``unicode`` object in Python 2 and a ``str`` object in Python 3.
 
 Test attributes
 ---------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyrsistent
 python-mimeparse
 unittest2>=1.0.0
 traceback2
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ pyrsistent
 python-mimeparse
 unittest2>=1.0.0
 traceback2
-six
+six>=1.4.0

--- a/testtools/__init__.py
+++ b/testtools/__init__.py
@@ -42,6 +42,7 @@ __all__ = [
     'TimestampingStreamResult',
     'try_import',
     'try_imports',
+    'unique_text_generator',
     ]
 
 # Compat - removal announced in 0.9.25.
@@ -77,6 +78,7 @@ else:
         skip,
         skipIf,
         skipUnless,
+        unique_text_generator,
         )
     from testtools.testresult import (
         CopyStreamResult,

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -21,6 +21,8 @@ import itertools
 import sys
 import types
 
+import six
+
 from extras import (
     safe_hasattr,
     try_import,
@@ -545,6 +547,22 @@ class TestCase(unittest.TestCase):
         if prefix is None:
             prefix = self.id()
         return '%s-%d' % (prefix, self.getUniqueInteger())
+
+    def getUniqueText(self, prefix=None):
+        """Generate text unique to this test.
+
+        Returns text that is guaranteed to be unique to this instance. Use
+        this when you need arbitrary text in your test, or as a helper
+        for custom anonymous factory methods.
+
+        :param prefix: The prefix of the string. If not provided, defaults
+            to the id of the test.
+        :return: text that looks like '<prefix>-<text_with_unicode>'.
+        :rtype: six.text_type
+        """
+        if prefix is None:
+            prefix = self.id()
+        return six.text_type('%s-%s') % (prefix, six.unichr(0x1e00))
 
     def onException(self, exc_info, tb_label='traceback'):
         """Called when an exception propogates from test code.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -22,8 +22,6 @@ import itertools
 import sys
 import types
 
-import six
-
 from extras import (
     safe_hasattr,
     try_import,
@@ -59,6 +57,7 @@ from testtools.testresult import (
     )
 
 wraps = try_import('functools.wraps')
+import six
 
 class TestSkipped(Exception):
     """Raised within TestCase.run() when a test is skipped."""

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -201,14 +201,12 @@ def unique_text_generator(prefix):
     :return: text that looks like '<prefix>-<text_with_unicode>'.
     :rtype: six.text_type
     """
-    index = 0
-
-    # 0x1e00 is the start of a range of chars that are easy to see are
+    # 0x1e00 is the start of a range of glyphs that are easy to see are
     # unicode since they've got circles and dots and other diacriticals.
     # 0x1eff is the end of the range of these diacritical chars.
     BASE_CP = 0x1e00
     CP_RANGE = 0x1f00 - BASE_CP
-
+    index = 0
     while True:
         unique_text = _unique_text(BASE_CP, CP_RANGE, index)
         yield six.text_type('%s-%s') % (prefix, unique_text)

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -191,6 +191,33 @@ def _unique_text(base_cp, cp_range, index):
     return s
 
 
+def unique_text_generator(prefix):
+    """Generates unique text values.
+
+    Generates text values that are unique. Use this when you need arbitrary
+    text in your test, or as a helper for custom anonymous factory methods.
+
+    :param prefix: The prefix for text. If this is a TestCase the id is used.
+    :return: text that looks like '<prefix>-<text_with_unicode>'.
+    :rtype: six.text_type
+    """
+    if hasattr(prefix, 'id'):
+        prefix = prefix.id()
+
+    index = 0
+
+    # 0x1e00 is the start of a range of chars that are easy to see are
+    # unicode since they've got circles and dots and other diacriticals.
+    # 0x1eff is the end of the range of these diacritical chars.
+    BASE_CP = 0x1e00
+    CP_RANGE = 0x1f00 - BASE_CP
+
+    while True:
+        unique_text = _unique_text(BASE_CP, CP_RANGE, index)
+        yield six.text_type('%s-%s') % (prefix, unique_text)
+        index = index + 1
+
+
 class TestCase(unittest.TestCase):
     """Extensions to the basic TestCase.
 

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -562,7 +562,8 @@ class TestCase(unittest.TestCase):
         """
         if prefix is None:
             prefix = self.id()
-        return six.text_type('%s-%s') % (prefix, six.unichr(0x1e00))
+        unique_text = six.unichr(0x1e00 + self.getUniqueInteger() - 1)
+        return six.text_type('%s-%s') % (prefix, unique_text)
 
     def onException(self, exc_info, tb_label='traceback'):
         """Called when an exception propogates from test code.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -197,13 +197,10 @@ def unique_text_generator(prefix):
     Generates text values that are unique. Use this when you need arbitrary
     text in your test, or as a helper for custom anonymous factory methods.
 
-    :param prefix: The prefix for text. If this is a TestCase the id is used.
+    :param prefix: The prefix for text.
     :return: text that looks like '<prefix>-<text_with_unicode>'.
     :rtype: six.text_type
     """
-    if hasattr(prefix, 'id'):
-        prefix = prefix.id()
-
     index = 0
 
     # 0x1e00 is the start of a range of chars that are easy to see are

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -581,9 +581,12 @@ class TestCase(unittest.TestCase):
 
         # 0x1e00 is the start of a range of chars that are easy to see are
         # unicode since they've got circles and dots and other diacriticals.
+        # 0x1eff is the end of the range of these diacritical chars.
         BASE_CP = 0x1e00
+        CP_RANGE = 0x1f00 - BASE_CP
 
-        unique_text = six.unichr(BASE_CP + self.getUniqueInteger() - 1)
+        unique_text = _unique_text(BASE_CP, CP_RANGE,
+                                   self.getUniqueInteger() - 1)
         return six.text_type('%s-%s') % (prefix, unique_text)
 
     def onException(self, exc_info, tb_label='traceback'):

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -562,7 +562,12 @@ class TestCase(unittest.TestCase):
         """
         if prefix is None:
             prefix = self.id()
-        unique_text = six.unichr(0x1e00 + self.getUniqueInteger() - 1)
+
+        # 0x1e00 is the start of a range of chars that are easy to see are
+        # unicode since they've got circles and dots and other diacriticals.
+        BASE_CP = 0x1e00
+
+        unique_text = six.unichr(BASE_CP + self.getUniqueInteger() - 1)
         return six.text_type('%s-%s') % (prefix, unique_text)
 
     def onException(self, exc_info, tb_label='traceback'):

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -565,11 +565,11 @@ class TestCase(unittest.TestCase):
         return '%s-%d' % (prefix, self.getUniqueInteger())
 
     def getUniqueText(self, prefix=None):
-        """Generate text unique to this test.
+        """Generate a text value unique to this test and invocation.
 
-        Returns text that is guaranteed to be unique to this instance. Use
-        this when you need arbitrary text in your test, or as a helper
-        for custom anonymous factory methods.
+        Returns a text value that is guaranteed to be unique to this
+        invocation. Use this when you need arbitrary text in your test, or as a
+        helper for custom anonymous factory methods.
 
         :param prefix: The prefix of the string. If not provided, defaults
             to the id of the test.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -591,31 +591,6 @@ class TestCase(unittest.TestCase):
             prefix = self.id()
         return '%s-%d' % (prefix, self.getUniqueInteger())
 
-    def getUniqueText(self, prefix=None):
-        """Generate a text value unique to this test and invocation.
-
-        Returns a text value that is guaranteed to be unique to this
-        invocation. Use this when you need arbitrary text in your test, or as a
-        helper for custom anonymous factory methods.
-
-        :param prefix: The prefix of the string. If not provided, defaults
-            to the id of the test.
-        :return: text that looks like '<prefix>-<text_with_unicode>'.
-        :rtype: six.text_type
-        """
-        if prefix is None:
-            prefix = self.id()
-
-        # 0x1e00 is the start of a range of chars that are easy to see are
-        # unicode since they've got circles and dots and other diacriticals.
-        # 0x1eff is the end of the range of these diacritical chars.
-        BASE_CP = 0x1e00
-        CP_RANGE = 0x1f00 - BASE_CP
-
-        unique_text = _unique_text(BASE_CP, CP_RANGE,
-                                   self.getUniqueInteger() - 1)
-        return six.text_type('%s-%s') % (prefix, unique_text)
-
     def onException(self, exc_info, tb_label='traceback'):
         """Called when an exception propogates from test code.
 

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -175,6 +175,22 @@ def gather_details(source_dict, target_dict):
         target_dict[name] = _copy_content(content_object)
 
 
+def _mods(i, mod):
+    (q, r) = divmod(i, mod)
+    while True:
+        yield r
+        if not q:
+            break
+        (q, r) = divmod(q, mod)
+
+
+def _unique_text(base_cp, cp_range, index):
+    s = six.text_type('')
+    for m in _mods(index, cp_range):
+        s += six.unichr(base_cp + m)
+    return s
+
+
 class TestCase(unittest.TestCase):
     """Extensions to the basic TestCase.
 

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -13,6 +13,7 @@ __all__ = [
     'skipIf',
     'skipUnless',
     'TestCase',
+    'unique_text_generator',
     ]
 
 import copy

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1092,12 +1092,20 @@ class TestUniqueFactories(TestCase):
         prefix = self.getUniqueString()
         unique_text_generator = testcase.unique_text_generator(prefix)
         first_result = next(unique_text_generator)
+        if sys.version_info[:2] == (3, 2):
+            expected_value = '\u1e00'
+        else:
+            expected_value = u'\u1e00'
         self.assertEqual(six.text_type('%s-%s') %
-                         (prefix, u'\u1e00'), first_result)
+                         (prefix, expected_value), first_result)
         # The next value yielded by unique_text_generator is different.
+        if sys.version_info[:2] == (3, 2):
+            expected_value = '\u1e01'
+        else:
+            expected_value = u'\u1e01'
         second_result = next(unique_text_generator)
         self.assertEqual(six.text_type('%s-%s') %
-                         (prefix, u'\u1e01'), second_result)
+                         (prefix, expected_value), second_result)
 
     def test_mods(self):
         # given a number and max, generate a list that's the mods.

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1038,7 +1038,7 @@ class TestExpectedFailure(TestWithDetails):
 
 
 class TestUniqueFactories(TestCase):
-    """Tests for getUniqueString, getUniqueInteger, and getUniqueText."""
+    """Tests for getUniqueString, getUniqueInteger, unique_text_generator."""
 
     run_test_with = FullStackRunTest
 
@@ -1066,14 +1066,15 @@ class TestUniqueFactories(TestCase):
         name_two = self.getUniqueString('bar')
         self.assertThat(name_two, Equals('bar-2'))
 
-    def test_getUniqueText(self):
-        # getUniqueText with no prefix returns current test ID followed by
-        # a unique unicode character.
-        first_result = self.getUniqueText()
+    def test_unique_text_generator(self):
+        # unique_text_generator yields the prefix's id followed by unique
+        # unicode string.
+        unique_text_generator = testcase.unique_text_generator(self)
+        first_result = unique_text_generator.next()
         self.assertEqual(six.text_type('%s-%s') %
                          (self.id(), u'\u1e00'), first_result)
-        # You get different text the next time getUniqueText is called.
-        second_result = self.getUniqueText()
+        # The next value yielded by unique_text_generator is different.
+        second_result = unique_text_generator.next()
         self.assertEqual(six.text_type('%s-%s') %
                          (self.id(), u'\u1e01'), second_result)
 

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1069,14 +1069,15 @@ class TestUniqueFactories(TestCase):
     def test_unique_text_generator(self):
         # unique_text_generator yields the prefix's id followed by unique
         # unicode string.
-        unique_text_generator = testcase.unique_text_generator(self)
+        prefix = self.getUniqueString()
+        unique_text_generator = testcase.unique_text_generator(prefix)
         first_result = unique_text_generator.next()
         self.assertEqual(six.text_type('%s-%s') %
-                         (self.id(), u'\u1e00'), first_result)
+                         (prefix, u'\u1e00'), first_result)
         # The next value yielded by unique_text_generator is different.
         second_result = unique_text_generator.next()
         self.assertEqual(six.text_type('%s-%s') %
-                         (self.id(), u'\u1e01'), second_result)
+                         (prefix, u'\u1e01'), second_result)
 
     def test_mods(self):
         # given a number and max, generate a list that's the mods.

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1071,11 +1071,11 @@ class TestUniqueFactories(TestCase):
         # unicode string.
         prefix = self.getUniqueString()
         unique_text_generator = testcase.unique_text_generator(prefix)
-        first_result = unique_text_generator.next()
+        first_result = next(unique_text_generator)
         self.assertEqual(six.text_type('%s-%s') %
                          (prefix, u'\u1e00'), first_result)
         # The next value yielded by unique_text_generator is different.
-        second_result = unique_text_generator.next()
+        second_result = next(unique_text_generator)
         self.assertEqual(six.text_type('%s-%s') %
                          (prefix, u'\u1e01'), second_result)
 

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1077,6 +1077,38 @@ class TestUniqueFactories(TestCase):
         self.assertEqual(six.text_type('%s-%s') %
                          (self.id(), u'\u1e01'), second_result)
 
+    def test_mods(self):
+        # given a number and max, generate a list that's the mods.
+        # The list should contain no numbers >= mod
+        self.assertEqual([0], list(testcase._mods(0, 5)))
+        self.assertEqual([1], list(testcase._mods(1, 5)))
+        self.assertEqual([2], list(testcase._mods(2, 5)))
+        self.assertEqual([3], list(testcase._mods(3, 5)))
+        self.assertEqual([4], list(testcase._mods(4, 5)))
+        self.assertEqual([0, 1], list(testcase._mods(5, 5)))
+        self.assertEqual([1, 1], list(testcase._mods(6, 5)))
+        self.assertEqual([2, 1], list(testcase._mods(7, 5)))
+        self.assertEqual([0, 2], list(testcase._mods(10, 5)))
+        self.assertEqual([0, 0, 1], list(testcase._mods(25, 5)))
+        self.assertEqual([1, 0, 1], list(testcase._mods(26, 5)))
+        self.assertEqual([1], list(testcase._mods(1, 100)))
+        self.assertEqual([0, 1], list(testcase._mods(100, 100)))
+        self.assertEqual([0, 10], list(testcase._mods(1000, 100)))
+
+    def test_unique_text(self):
+        self.assertEqual(
+            u'\u1e00',
+            testcase._unique_text(base_cp=0x1e00, cp_range=5, index=0))
+        self.assertEqual(
+            u'\u1e01',
+            testcase._unique_text(base_cp=0x1e00, cp_range=5, index=1))
+        self.assertEqual(
+            u'\u1e00\u1e01',
+            testcase._unique_text(base_cp=0x1e00, cp_range=5, index=5))
+        self.assertEqual(
+            u'\u1e03\u1e02\u1e01',
+            testcase._unique_text(base_cp=0x1e00, cp_range=5, index=38))
+
 
 class TestCloneTestWithNewId(TestCase):
     """Tests for clone_test_with_new_id."""

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1069,9 +1069,13 @@ class TestUniqueFactories(TestCase):
     def test_getUniqueText(self):
         # getUniqueText with no prefix returns current test ID followed by
         # a unique unicode character.
-        text_one = self.getUniqueText()
+        first_result = self.getUniqueText()
         self.assertEqual(six.text_type('%s-%s') %
-                         (self.id(), six.unichr(0x1e00)), text_one)
+                         (self.id(), u'\u1e00'), first_result)
+        # You get different text the next time getUniqueText is called.
+        second_result = self.getUniqueText()
+        self.assertEqual(six.text_type('%s-%s') %
+                         (self.id(), u'\u1e01'), second_result)
 
 
 class TestCloneTestWithNewId(TestCase):

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -7,6 +7,8 @@ from pprint import pformat
 import sys
 import unittest
 
+import six
+
 from testtools import (
     DecorateTestCaseResult,
     ErrorHolder,
@@ -1036,7 +1038,7 @@ class TestExpectedFailure(TestWithDetails):
 
 
 class TestUniqueFactories(TestCase):
-    """Tests for getUniqueString and getUniqueInteger."""
+    """Tests for getUniqueString, getUniqueInteger, and getUniqueText."""
 
     run_test_with = FullStackRunTest
 
@@ -1063,6 +1065,13 @@ class TestUniqueFactories(TestCase):
         self.assertThat(name_one, Equals('foo-1'))
         name_two = self.getUniqueString('bar')
         self.assertThat(name_two, Equals('bar-2'))
+
+    def test_getUniqueText(self):
+        # getUniqueText with no prefix returns current test ID followed by
+        # a unique unicode character.
+        text_one = self.getUniqueText()
+        self.assertEqual(six.text_type('%s-%s') %
+                         (self.id(), six.unichr(0x1e00)), text_one)
 
 
 class TestCloneTestWithNewId(TestCase):

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1092,20 +1092,12 @@ class TestUniqueFactories(TestCase):
         prefix = self.getUniqueString()
         unique_text_generator = testcase.unique_text_generator(prefix)
         first_result = next(unique_text_generator)
-        if sys.version_info[:2] == (3, 2):
-            expected_value = '\u1e00'
-        else:
-            expected_value = u'\u1e00'
-        self.assertEqual(six.text_type('%s-%s') %
-                         (prefix, expected_value), first_result)
+        self.assertEqual(six.text_type('%s-%s') % (prefix, _u('\u1e00')),
+                         first_result)
         # The next value yielded by unique_text_generator is different.
-        if sys.version_info[:2] == (3, 2):
-            expected_value = '\u1e01'
-        else:
-            expected_value = u'\u1e01'
         second_result = next(unique_text_generator)
-        self.assertEqual(six.text_type('%s-%s') %
-                         (prefix, expected_value), second_result)
+        self.assertEqual(six.text_type('%s-%s') % (prefix, _u('\u1e01')),
+                         second_result)
 
     def test_mods(self):
         # given a number and max, generate a list that's the mods.


### PR DESCRIPTION
A generator is provided that generates unique (unicode) text strings. This is handy for tests that would prefer to use unicode strings in order to validate that their code works properly with unicode characters.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/176)
<!-- Reviewable:end -->
