### PR TITLE
Enable as_text() for JSON

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ classifier =
 [extras]
 test =
   fixtures
+  hypothesis
   testscenarios
   unittest2>=1.1.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,6 @@ classifier =
 [extras]
 test =
   fixtures
-  hypothesis
   testscenarios
   unittest2>=1.1.0
 

--- a/testtools/content.py
+++ b/testtools/content.py
@@ -104,7 +104,7 @@ class Content(object):
 
         :raises ValueError: If the content type is not text/\*.
         """
-        if self.content_type.type != "text":
+        if not self.content_type.is_text():
             raise ValueError("Not a text type %r" % self.content_type)
         return self._iter_text()
 

--- a/testtools/content_type.py
+++ b/testtools/content_type.py
@@ -42,6 +42,7 @@ class ContentType(object):
         return self.type == 'text' or self._text_override
 
 
-JSON = ContentType('application', 'json', text_override=True)
+JSON = ContentType(
+    'application', 'json', {'charset': 'utf8'}, text_override=True)
 
 UTF8_TEXT = ContentType('text', 'plain', {'charset': 'utf8'})

--- a/testtools/content_type.py
+++ b/testtools/content_type.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2009-2015 testtools developers. See LICENSE for details.
 
 """ContentType - a MIME Content Type."""
 
@@ -34,6 +34,10 @@ class ContentType(object):
         else:
             params = ''
         return "%s/%s%s" % (self.type, self.subtype, params)
+
+    def is_text(self):
+        """True if this content type can be converted to text."""
+        return self.type == 'text'
 
 
 JSON = ContentType('application', 'json')

--- a/testtools/content_type.py
+++ b/testtools/content_type.py
@@ -12,7 +12,8 @@ class ContentType(object):
         content type.
     """
 
-    def __init__(self, primary_type, sub_type, parameters=None):
+    def __init__(self, primary_type, sub_type, parameters=None,
+                 text_override=False):
         """Create a ContentType."""
         if None in (primary_type, sub_type):
             raise ValueError("None not permitted in %r, %r" % (
@@ -20,6 +21,7 @@ class ContentType(object):
         self.type = primary_type
         self.subtype = sub_type
         self.parameters = parameters or {}
+        self._text_override = text_override
 
     def __eq__(self, other):
         if type(other) != ContentType:
@@ -37,9 +39,9 @@ class ContentType(object):
 
     def is_text(self):
         """True if this content type can be converted to text."""
-        return self.type == 'text'
+        return self.type == 'text' or self._text_override
 
 
-JSON = ContentType('application', 'json')
+JSON = ContentType('application', 'json', text_override=True)
 
 UTF8_TEXT = ContentType('text', 'plain', {'charset': 'utf8'})

--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -212,6 +212,13 @@ class TestContent(TestCase):
         expected = Content(JSON, lambda: [_b('{"foo": "bar"}')])
         self.assertEqual(expected, json_content(data))
 
+    def test_json_content_as_text(self):
+        # JSON content can be converted to text, even though it's not strictly
+        # text content.
+        data = {'foo': 'bar'}
+        content = Content(JSON, lambda: [json.dumps(data).encode('utf8')])
+        self.assertThat(json.loads(content.as_text()), Equals(data))
+
 
 class TestStackLinesContent(TestCase):
 

--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -215,7 +215,7 @@ class TestContent(TestCase):
     def test_json_content_as_text(self):
         # JSON content can be converted to text, even though it's not strictly
         # text content.
-        data = {'foo': 'bar'}
+        data = {_u('foo'): _u('bar'), _u('qux'): _u("A\xA7")}
         content = Content(JSON, lambda: [json.dumps(data).encode('utf8')])
         self.assertThat(json.loads(content.as_text()), Equals(data))
 

--- a/testtools/tests/test_content_type.py
+++ b/testtools/tests/test_content_type.py
@@ -1,7 +1,5 @@
 # Copyright (c) 2008, 2012 testtools developers. See LICENSE for details.
 
-from hypothesis import given
-from hypothesis.strategies import dictionaries, text
 from testtools import TestCase
 from testtools.matchers import Equals, MatchesException, Raises
 from testtools.content_type import (
@@ -47,10 +45,9 @@ class TestContentType(TestCase):
         self.assertThat(
             repr(content_type), Equals('text/plain; baz="qux"; foo="bar"'))
 
-    @given(text(average_size=5),
-           dictionaries(text(average_size=5), text(average_size=5)))
-    def test_text_type_is_text(self, subtype, parameters):
-        content_type = ContentType('text', subtype, parameters)
+    def test_text_type_is_text(self):
+        subtype = 'arbitrary-subtype'
+        content_type = ContentType('text', subtype)
         self.assertThat(content_type.is_text(), Equals(True))
 
 

--- a/testtools/tests/test_content_type.py
+++ b/testtools/tests/test_content_type.py
@@ -64,7 +64,7 @@ class TestBuiltinContentTypes(TestCase):
         # The JSON content type represents implictly UTF-8 application/json.
         self.assertThat(JSON.type, Equals('application'))
         self.assertThat(JSON.subtype, Equals('json'))
-        self.assertThat(JSON.parameters, Equals({}))
+        self.assertThat(JSON.parameters, Equals({'charset': 'utf8'}))
         self.assertThat(JSON.is_text(), Equals(True))
 
 

--- a/testtools/tests/test_content_type.py
+++ b/testtools/tests/test_content_type.py
@@ -68,6 +68,7 @@ class TestBuiltinContentTypes(TestCase):
         self.assertThat(JSON.type, Equals('application'))
         self.assertThat(JSON.subtype, Equals('json'))
         self.assertThat(JSON.parameters, Equals({}))
+        self.assertThat(JSON.is_text(), Equals(True))
 
 
 def test_suite():

--- a/testtools/tests/test_content_type.py
+++ b/testtools/tests/test_content_type.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2008, 2012 testtools developers. See LICENSE for details.
 
+from hypothesis import given
+from hypothesis.strategies import dictionaries, text
 from testtools import TestCase
 from testtools.matchers import Equals, MatchesException, Raises
 from testtools.content_type import (
@@ -45,6 +47,12 @@ class TestContentType(TestCase):
         self.assertThat(
             repr(content_type), Equals('text/plain; baz="qux"; foo="bar"'))
 
+    @given(text(average_size=5),
+           dictionaries(text(average_size=5), text(average_size=5)))
+    def test_text_type_is_text(self, subtype, parameters):
+        content_type = ContentType('text', subtype, parameters)
+        self.assertThat(content_type.is_text(), Equals(True))
+
 
 class TestBuiltinContentTypes(TestCase):
 
@@ -53,6 +61,7 @@ class TestBuiltinContentTypes(TestCase):
         self.assertThat(UTF8_TEXT.type, Equals('text'))
         self.assertThat(UTF8_TEXT.subtype, Equals('plain'))
         self.assertThat(UTF8_TEXT.parameters, Equals({'charset': 'utf8'}))
+        self.assertThat(UTF8_TEXT.is_text(), Equals(True))
 
     def test_json_content(self):
         # The JSON content type represents implictly UTF-8 application/json.


### PR DESCRIPTION
It's super useful to be able to attach a chunk of JSON data to a test and then see that data when the test fails. 

This approach has its defects (e.g. it doesn't pretty print the JSON), but maybe it's OK, and a patch is a great way to start a conversation.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/177)
<!-- Reviewable:end -->
