### PR TITLE
Add map_bytes for Content

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -11,8 +11,9 @@ Changes
 
 * Add a new test dependency of testscenarios. (Robert Collins)
 
-* New method ``Content.map_bytes`` that can be used to return a new ``Content``
-  object of the same type with data based on the original. (Jonathan Lange)
+* New function ``map_bytes`` that can be used to map a ``Content`` object to a
+  new ``Content`` of the same content type with data based on the original.
+  (Jonathan Lange)
 
 1.8.1
 ~~~~~

--- a/NEWS
+++ b/NEWS
@@ -10,7 +10,10 @@ Changes
 -------
 
 * Add a new test dependency of testscenarios. (Robert Collins)
-  
+
+* New method ``Content.map_bytes`` that can be used to return a new ``Content``
+  object of the same type with data based on the original. (Jonathan Lange)
+
 1.8.1
 ~~~~~
 

--- a/testtools/content.py
+++ b/testtools/content.py
@@ -69,7 +69,7 @@ class Content(object):
     """
 
     def __init__(self, content_type, get_bytes):
-        """Create a ContentType."""
+        """Create a Content."""
         if None in (content_type, get_bytes):
             raise ValueError("None not permitted in %r, %r" % (
                 content_type, get_bytes))
@@ -119,6 +119,17 @@ class Content(object):
     def __repr__(self):
         return "<Content type=%r, value=%r>" % (
             self.content_type, _join_b(self.iter_bytes()))
+
+    def map_bytes(self, function):
+        """Map ``function`` over data to create a new Content of the same type.
+
+        :param function: Unary callable that expects an iterable of bytes and
+            yields bytes.
+        :return: A ``Content`` object of the same type as ``self`` with bytes
+            that come from ``function``.
+        """
+        return self.__class__(
+            self.content_type, lambda: function(self.iter_bytes()))
 
 
 class StackLinesContent(Content):

--- a/testtools/content.py
+++ b/testtools/content.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2009-2015 testtools developers. See LICENSE for details.
 
 """Content - a MIME-like Content object."""
 
@@ -13,10 +13,8 @@ __all__ = [
     ]
 
 import codecs
-import inspect
 import json
 import os
-import sys
 
 from extras import try_import
 # To let setup.py work, make this a conditional import.

--- a/testtools/content.py
+++ b/testtools/content.py
@@ -120,16 +120,19 @@ class Content(object):
         return "<Content type=%r, value=%r>" % (
             self.content_type, _join_b(self.iter_bytes()))
 
-    def map_bytes(self, function):
-        """Map ``function`` over data to create a new Content of the same type.
 
-        :param function: Unary callable that expects an iterable of bytes and
-            yields bytes.
-        :return: A ``Content`` object of the same type as ``self`` with bytes
-            that come from ``function``.
-        """
-        return self.__class__(
-            self.content_type, lambda: function(self.iter_bytes()))
+def map_bytes(function, content):
+    """Map ``function`` over data in ``content``.
+
+    Creates a new Content of the same content type as ``content``.
+
+    :param function: Unary callable that expects an iterable of bytes and
+        yields bytes.
+    :param content: A content object.
+    :return: A ``Content`` object with bytes that come from ``function``.
+    """
+    return Content(
+        content.content_type, lambda: function(content.iter_bytes()))
 
 
 class StackLinesContent(Content):

--- a/testtools/content.py
+++ b/testtools/content.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2015 testtools developers. See LICENSE for details.
+# Copyright (c) 2009-2016 testtools developers. See LICENSE for details.
 
 """Content - a MIME-like Content object."""
 
@@ -10,6 +10,7 @@ __all__ = [
     'json_content',
     'text_content',
     'TracebackContent',
+    'map_bytes',
     ]
 
 import codecs

--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -214,8 +214,8 @@ class TestContent(TestCase):
     def test_map_bytes_identical(self):
         # Given the identity function, map_bytes returns a Content with the
         # same data as the original.
-        data = _u('some data').encode('utf8')
-        content = Content(UTF8_TEXT, lambda: iter(data))
+        data = [_u('some data').encode('utf8')]
+        content = Content(UTF8_TEXT, lambda: data)
         new_content = content.map_bytes(lambda x: x)
         self.assertThat(new_content.as_text(), Equals(content.as_text()))
 

--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -211,6 +211,28 @@ class TestContent(TestCase):
         expected = Content(JSON, lambda: [_b('{"foo": "bar"}')])
         self.assertEqual(expected, json_content(data))
 
+    def test_map_bytes_identical(self):
+        # Given the identity function, map_bytes returns a Content with the
+        # same data as the original.
+        data = 'some data'
+        content = Content(UTF8_TEXT, lambda: iter(data))
+        new_content = content.map_bytes(lambda x: x)
+        self.assertThat(new_content.as_text(), Equals(content.as_text()))
+
+    def test_map_bytes_different(self):
+        # For all functions that map iterable of data to iterable of data, and
+        # for data, iterating over the bytes of the content returned by
+        # map_bytes(f) is equivalent to mapping f over the iter_bytes of the
+        # original content.
+        data = 'some data'
+        function = lambda x: reversed(list(x))
+
+        content = Content(UTF8_TEXT, lambda: iter(data))
+        new_content = content.map_bytes(lambda x: function(x))
+        self.assertThat(
+            list(new_content.iter_bytes()),
+            Equals(list(function(content.iter_bytes()))))
+
 
 class TestStackLinesContent(TestCase):
 

--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -214,7 +214,7 @@ class TestContent(TestCase):
     def test_map_bytes_identical(self):
         # Given the identity function, map_bytes returns a Content with the
         # same data as the original.
-        data = 'some data'
+        data = _u('some data').encode('utf8')
         content = Content(UTF8_TEXT, lambda: iter(data))
         new_content = content.map_bytes(lambda x: x)
         self.assertThat(new_content.as_text(), Equals(content.as_text()))
@@ -224,7 +224,7 @@ class TestContent(TestCase):
         # for data, iterating over the bytes of the content returned by
         # map_bytes(f) is equivalent to mapping f over the iter_bytes of the
         # original content.
-        data = 'some data'
+        data = _u('some data').encode('utf8')
         function = lambda x: reversed(list(x))
 
         content = Content(UTF8_TEXT, lambda: iter(data))

--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -19,6 +19,7 @@ from testtools.content import (
     content_from_stream,
     JSON,
     json_content,
+    map_bytes,
     StackLinesContent,
     StacktraceContent,
     TracebackContent,
@@ -216,7 +217,7 @@ class TestContent(TestCase):
         # same data as the original.
         data = [_u('some data').encode('utf8')]
         content = Content(UTF8_TEXT, lambda: data)
-        new_content = content.map_bytes(lambda x: x)
+        new_content = map_bytes(lambda x: x, content)
         self.assertThat(new_content.as_text(), Equals(content.as_text()))
 
     def test_map_bytes_different(self):
@@ -228,7 +229,7 @@ class TestContent(TestCase):
         function = lambda x: reversed(list(x))
 
         content = Content(UTF8_TEXT, lambda: iter(data))
-        new_content = content.map_bytes(lambda x: function(x))
+        new_content = map_bytes(function, content)
         self.assertThat(
             list(new_content.iter_bytes()),
             Equals(list(function(content.iter_bytes()))))

--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -1,6 +1,5 @@
-# Copyright (c) 2008-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
-import json
 import os
 import tempfile
 import unittest


### PR DESCRIPTION
Makes `Content` a functor, which can be handy for some operations.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/179)
<!-- Reviewable:end -->
