### PR TITLE
Support Python 3.5, announce deprecation of Python 3.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
   - "pypy"
 
 # We have to pin Jinja2 < 2.7  for Python 3.2 because 2.7 drops/breaks support:

--- a/NEWS
+++ b/NEWS
@@ -6,11 +6,18 @@ Changes and improvements to testtools_, grouped by release.
 Next
 ~~~~
 
+Improvements
+------------
+
+* Python 3.5 added to the list of supported platforms. (Jonathan Lange)
+
 Changes
 -------
 
 * Add a new test dependency of testscenarios. (Robert Collins)
-  
+
+* Last release of testtools to support Python 3.2. (Jonathan Lange)
+
 1.8.1
 ~~~~~
 

--- a/NEWS
+++ b/NEWS
@@ -1172,7 +1172,7 @@ Improvements
 * Malformed SyntaxErrors no longer blow up the test suite.  (Martin [gz])
 
 * ``MismatchesAll.describe`` no longer appends a trailing newline.
-  (Michael Hudrrson-Doyle, #686790)
+  (Michael Hudson-Doyle, #686790)
 
 * New helpers for conditionally importing modules, ``try_import`` and
   ``try_imports``.  (Jonathan Lange)

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ under the same license as Python, see LICENSE for details.
 Required Dependencies
 ---------------------
 
- * Python 2.6+ or 3.0+ / pypy (2.x+)
+ * Python 2.6+ or 3.2+ / pypy (2.x+)
 
 If you would like to use testtools for earlier Python's, please use testtools
 0.9.15.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -93,7 +93,7 @@ Cross-Python compatibility
 --------------------------
 
 testtools gives you the very latest in unit testing technology in a way that
-will work with Python 2.6, 2.7, 3.1 and 3.2.
+will work with Python 2.6, 2.7, 3.2, 3.3, 3.4, and 3.5.
 
 If you wish to use testtools with Python 2.4 or 2.5, then please use testtools
 0.9.15. Up to then we supported Python 2.4 and 2.5, but we found the


### PR DESCRIPTION
This patch adds Python 3.5 to the documented supported Pythons, and to the Travis file. It also announces that this will be the last release to support Python 3.2.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/180)
<!-- Reviewable:end -->
