### PR TITLE
Interfaces for Matchers

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,11 +12,21 @@ Improvements
 * ``MatchesListwise`` has more informative error when lengths don't match.
   (Jonathan Lange)
 
+* Explicit interfaces for matchers (``IMatcher``) and mismatches
+  (``IMismatch``), explicitly documenting the contract expected by
+  ``assertThat`` and ``MismatchError``. (Jonathan Lange)
+
 Changes
 -------
 
 * Add a new test dependency of testscenarios. (Robert Collins)
-  
+
+* New dependency on zope.interface. (Jonathan Lange)
+
+* The ``describe`` method on mismatches must return unicode on Python 2 and
+  str on Python 3. Mismatches that return ASCII-encoded bytes will continue
+  to work, but will emit deprecation warnings. (Jonathan Lange)
+
 1.8.1
 ~~~~~
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyrsistent
 python-mimeparse
 unittest2>=1.0.0
 traceback2
+zope.interface

--- a/testtools/assertions.py
+++ b/testtools/assertions.py
@@ -1,7 +1,9 @@
 from testtools.matchers import (
     Annotate,
+    IMatcher,
+    IMismatch,
     MismatchError,
-    )
+)
 
 
 def assert_that(matchee, matcher, message='', verbose=False):
@@ -12,11 +14,12 @@ def assert_that(matchee, matcher, message='', verbose=False):
     features
 
     :param matchee: An object to match with matcher.
-    :param matcher: An object meeting the testtools.Matcher protocol.
+    :param IMatcher matcher: The matcher to match with.
     :raises MismatchError: When matcher does not match thing.
     """
-    matcher = Annotate.if_message(message, matcher)
+    matcher = Annotate.if_message(message, IMatcher(matcher, matcher))
     mismatch = matcher.match(matchee)
     if not mismatch:
         return
-    raise MismatchError(matchee, matcher, mismatch, verbose)
+    raise MismatchError(
+        matchee, matcher, IMismatch(mismatch, mismatch), verbose)

--- a/testtools/compat.py
+++ b/testtools/compat.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
-"""Compatibility support for python 2 and 3."""
+"""Compatibility support for Python 2 and 3."""
 
 __metaclass__ = type
 __all__ = [
@@ -21,9 +21,7 @@ import codecs
 import io
 import locale
 import os
-import re
 import sys
-import traceback
 import unicodedata
 
 from extras import try_import, try_imports
@@ -68,6 +66,7 @@ if sys.version_info > (3, 0):
         return (type,)
     str_is_unicode = True
     text_or_bytes = (str, bytes)
+    text = str
 else:
     import __builtin__ as builtins
     def _u(s):
@@ -86,6 +85,7 @@ else:
         return (type, types.ClassType)
     str_is_unicode = sys.platform == "cli"
     text_or_bytes = (unicode, str)
+    text = unicode
 
 _u.__doc__ = __u_doc
 

--- a/testtools/matchers/__init__.py
+++ b/testtools/matchers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
 """All the matchers.
 
@@ -13,6 +13,11 @@ $ python -c 'import testtools.matchers; print testtools.matchers.__all__'
 """
 
 __all__ = [
+    # Interfaces
+    'IMatcher',
+    'IMismatch',
+
+    # Matchers
     'AfterPreprocessing',
     'AllMatch',
     'Annotate',
@@ -109,6 +114,10 @@ from ._higherorder import (
     MatchesPredicateWithParams,
     Not,
     )
+from ._imatcher import (
+    IMatcher,
+    IMismatch,
+)
 
 # XXX: These are not explicitly included in __all__.  It's unclear how much of
 # the public interface they really are.

--- a/testtools/matchers/_basic.py
+++ b/testtools/matchers/_basic.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2009-2015 testtools developers. See LICENSE for details.
 
 __all__ = [
     'Contains',
@@ -18,6 +18,8 @@ import operator
 from pprint import pformat
 import re
 
+from zope.interface import implementer
+
 from ..compat import (
     _isbytes,
     istext,
@@ -29,6 +31,7 @@ from ._higherorder import (
     MatchesPredicateWithParams,
     PostfixedMismatch,
     )
+from ._imatcher import IMatcher
 from ._impl import (
     Matcher,
     Mismatch,
@@ -45,6 +48,7 @@ def _format(thing):
     return pformat(thing)
 
 
+@implementer(IMatcher)
 class _BinaryComparison(object):
     """Matcher that compares an object to another object."""
 
@@ -216,6 +220,7 @@ class EndsWith(Matcher):
         return None
 
 
+@implementer(IMatcher)
 class IsInstance(object):
     """Matcher that wraps isinstance."""
 
@@ -290,6 +295,7 @@ class Contains(Matcher):
         return None
 
 
+@implementer(IMatcher)
 class MatchesRegex(object):
     """Matches if the matchee is matched by a regular expression."""
 

--- a/testtools/matchers/_basic.py
+++ b/testtools/matchers/_basic.py
@@ -22,6 +22,7 @@ from zope.interface import implementer
 
 from ..compat import (
     _isbytes,
+    _u,
     istext,
     str_is_unicode,
     text_repr,
@@ -79,11 +80,11 @@ class _BinaryMismatch(Mismatch):
         left = repr(self.expected)
         right = repr(self.other)
         if len(left) + len(right) > 70:
-            return "%s:\nreference = %s\nactual    = %s\n" % (
+            return _u("%s:\nreference = %s\nactual    = %s\n") % (
                 self._mismatch_string, _format(self.expected),
                 _format(self.other))
         else:
-            return "%s %s %s" % (left, self._mismatch_string, right)
+            return _u("%s %s %s") % (left, self._mismatch_string, right)
 
 
 class Equals(_BinaryComparison):
@@ -252,9 +253,9 @@ class NotAnInstance(Mismatch):
         if len(self.types) == 1:
             typestr = self.types[0].__name__
         else:
-            typestr = 'any of (%s)' % ', '.join(type.__name__ for type in
-                    self.types)
-        return "'%s' is not an instance of %s" % (self.matchee, typestr)
+            typestr = _u('any of (%s)') % _u(', ').join(
+                type.__name__ for type in self.types)
+        return _u("'%s' is not an instance of %s") % (self.matchee, typestr)
 
 
 class DoesNotContain(Mismatch):
@@ -269,7 +270,7 @@ class DoesNotContain(Mismatch):
         self.needle = needle
 
     def describe(self):
-        return "%r not in %r" % (self.needle, self.matchee)
+        return _u("%r not in %r") % (self.needle, self.matchee)
 
 
 class Contains(Matcher):
@@ -329,4 +330,5 @@ def has_len(x, y):
     return len(x) == y
 
 
-HasLength = MatchesPredicateWithParams(has_len, "len({0}) != {1}", "HasLength")
+HasLength = MatchesPredicateWithParams(
+    has_len, _u("len({0}) != {1}"), _u("HasLength"))

--- a/testtools/matchers/_datastructures.py
+++ b/testtools/matchers/_datastructures.py
@@ -9,12 +9,15 @@ __all__ = [
 
 """Matchers that operate with knowledge of Python data structures."""
 
+from zope.interface import implementer
+
 from ..helpers import map_values
 from ._higherorder import (
     Annotate,
     MatchesAll,
     MismatchesAll,
     )
+from ._imatcher import IMatcher
 from ._impl import Mismatch
 
 
@@ -29,6 +32,7 @@ def ContainsAll(items):
     return MatchesAll(*map(Contains, items), first_only=False)
 
 
+@implementer(IMatcher)
 class MatchesListwise(object):
     """Matches if each matcher matches the corresponding value.
 
@@ -74,6 +78,7 @@ class MatchesListwise(object):
             return MismatchesAll(mismatches)
 
 
+@implementer(IMatcher)
 class MatchesStructure(object):
     """Matcher that matches an object structurally.
 
@@ -149,6 +154,7 @@ class MatchesStructure(object):
         return MatchesListwise(matchers).match(values)
 
 
+@implementer(IMatcher)
 class MatchesSetwise(object):
     """Matches if all the matchers match elements of the value being matched.
 

--- a/testtools/matchers/_dict.py
+++ b/testtools/matchers/_dict.py
@@ -1,9 +1,10 @@
-# Copyright (c) 2009-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2009-2015 testtools developers. See LICENSE for details.
 
 __all__ = [
     'KeysEqual',
     ]
 
+from testtools.compat import _u
 from ..helpers import (
     dict_subtract,
     filter_values,
@@ -54,12 +55,12 @@ class DictMismatches(Mismatch):
         self.mismatches = mismatches
 
     def describe(self):
-        lines = ['{']
+        lines = [_u('{')]
         lines.extend(
-            ['  %r: %s,' % (key, mismatch.describe())
+            [_u('  %r: %s,') % (key, mismatch.describe())
              for (key, mismatch) in sorted(self.mismatches.items())])
-        lines.append('}')
-        return '\n'.join(lines)
+        lines.append(_u('}'))
+        return _u('\n').join(lines)
 
 
 def _dict_to_mismatch(data, to_mismatch=None,

--- a/testtools/matchers/_doctest.py
+++ b/testtools/matchers/_doctest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2009-2015 testtools developers. See LICENSE for details.
 
 __all__ = [
     'DocTestMatches',
@@ -7,8 +7,11 @@ __all__ = [
 import doctest
 import re
 
+from zope.interface import implementer
+
 from ..compat import str_is_unicode
 from ._impl import Mismatch
+from ._imatcher import IMatcher
 
 
 class _NonManglingOutputChecker(doctest.OutputChecker):
@@ -49,6 +52,7 @@ class _NonManglingOutputChecker(doctest.OutputChecker):
         del __F, __f, __g, _indent
 
 
+@implementer(IMatcher)
 class DocTestMatches(object):
     """See if a string matches a doctest example."""
 

--- a/testtools/matchers/_doctest.py
+++ b/testtools/matchers/_doctest.py
@@ -65,7 +65,7 @@ class DocTestMatches(object):
         """
         if not example.endswith('\n'):
             example += '\n'
-        self.want = example # required variable name by doctest.
+        self.want = example  # required variable name by doctest.
         self.flags = flags
         self._checker = _NonManglingOutputChecker()
 
@@ -105,4 +105,4 @@ class DocTestMismatch(Mismatch):
             return s
         # GZ 2011-08-24: This is actually pretty bogus, most C0 codes should
         #                be escaped, in addition to non-ascii bytes.
-        return s.decode("latin1").encode("ascii", "backslashreplace")
+        return s.decode("latin1")

--- a/testtools/matchers/_exception.py
+++ b/testtools/matchers/_exception.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2009-2015 testtools developers. See LICENSE for details.
 
 __all__ = [
     'MatchesException',
@@ -9,6 +9,7 @@ __all__ = [
 import sys
 
 from testtools.compat import (
+    _u,
     classtypes,
     istext,
     )
@@ -17,7 +18,7 @@ from ._higherorder import AfterPreproccessing
 from ._impl import (
     Matcher,
     Mismatch,
-    )
+)
 
 
 _error_repr = BaseException.__repr__
@@ -54,20 +55,22 @@ class MatchesException(Matcher):
             value_re = AfterPreproccessing(str, MatchesRegex(value_re), False)
         self.value_re = value_re
         expected_type = type(self.expected)
-        self._is_instance = not any(issubclass(expected_type, class_type)
-                for class_type in classtypes() + (tuple,))
+        self._is_instance = not any(
+            issubclass(expected_type, class_type)
+            for class_type in classtypes() + (tuple,))
 
     def match(self, other):
         if type(other) != tuple:
-            return Mismatch('%r is not an exc_info tuple' % other)
+            return Mismatch(_u('%r is not an exc_info tuple') % other)
         expected_class = self.expected
         if self._is_instance:
             expected_class = expected_class.__class__
         if not issubclass(other[0], expected_class):
-            return Mismatch('%r is not a %r' % (other[0], expected_class))
+            return Mismatch(_u('%r is not a %r') % (other[0], expected_class))
         if self._is_instance:
             if other[1].args != self.expected.args:
-                return Mismatch('%s has different arguments to %s.' % (
+                return Mismatch(
+                    _u('%s has different arguments to %s.') % (
                         _error_repr(other[1]), _error_repr(self.expected)))
         elif self.value_re is not None:
             return self.value_re.match(other[1])

--- a/testtools/matchers/_filesystem.py
+++ b/testtools/matchers/_filesystem.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2009-2015 testtools developers. See LICENSE for details.
 
 """Matchers for things related to the filesystem."""
 
@@ -15,6 +15,7 @@ __all__ = [
 import os
 import tarfile
 
+from testtools.compat import _u
 from ._basic import Equals
 from ._higherorder import (
     MatchesAll,
@@ -32,14 +33,14 @@ def PathExists():
 
       assertThat('/some/path', PathExists())
     """
-    return MatchesPredicate(os.path.exists, "%s does not exist.")
+    return MatchesPredicate(os.path.exists, _u("%s does not exist."))
 
 
 def DirExists():
     """Matches if the path exists and is a directory."""
     return MatchesAll(
         PathExists(),
-        MatchesPredicate(os.path.isdir, "%s is not a directory."),
+        MatchesPredicate(os.path.isdir, _u("%s is not a directory.")),
         first_only=True)
 
 
@@ -47,7 +48,7 @@ def FileExists():
     """Matches if the given path exists and is a file."""
     return MatchesAll(
         PathExists(),
-        MatchesPredicate(os.path.isfile, "%s is not a file."),
+        MatchesPredicate(os.path.isfile, _u("%s is not a file.")),
         first_only=True)
 
 

--- a/testtools/matchers/_higherorder.py
+++ b/testtools/matchers/_higherorder.py
@@ -13,7 +13,8 @@ __all__ = [
 import types
 from zope.interface import implementer
 
-from ._imatcher import IMatcher
+from testtools.compat import _u, text
+from ._imatcher import IMatcher, _text_deprecation
 from ._impl import (
     Matcher,
     Mismatch,
@@ -118,7 +119,7 @@ class MatchedUnexpectedly(Mismatch):
         self.other = other
 
     def describe(self):
-        return "%r matches %s" % (self.other, self.matcher)
+        return _u("%r matches %s") % (self.other, self.matcher)
 
 
 @implementer(IMatcher)
@@ -285,7 +286,9 @@ class MatchesPredicate(Matcher):
             a value that will be interpreted as a boolean.
         :param message: A message to describe a mismatch.  It will be formatted
             with '%' and be given whatever was passed to ``match()``. Thus, it
-            needs to contain exactly one thing like '%s', '%d' or '%f'.
+            needs to contain exactly one thing like '%s', '%d' or '%f'. It must
+            be text, not bytes (i.e. ``unicode`` on Python 2, ``str`` on
+            Python 3)
         """
         self.predicate = predicate
         self.message = message
@@ -324,6 +327,9 @@ def MatchesPredicateWithParams(predicate, message, name=None):
     :param message: A format string for describing mis-matches.
     :param name: Optional replacement name for the matcher.
     """
+    if not isinstance(message, text):
+        _text_deprecation(message)
+
     def construct_matcher(*args, **kwargs):
         return _MatchesPredicateWithParams(
             predicate, message, name, *args, **kwargs)

--- a/testtools/matchers/_higherorder.py
+++ b/testtools/matchers/_higherorder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2009-2015 testtools developers. See LICENSE for details.
 
 __all__ = [
     'AfterPreprocessing',
@@ -11,7 +11,9 @@ __all__ = [
     ]
 
 import types
+from zope.interface import implementer
 
+from ._imatcher import IMatcher
 from ._impl import (
     Matcher,
     Mismatch,
@@ -19,6 +21,7 @@ from ._impl import (
     )
 
 
+@implementer(IMatcher)
 class MatchesAny(object):
     """Matches if any of the matchers it is created with match."""
 
@@ -39,6 +42,7 @@ class MatchesAny(object):
             str(matcher) for matcher in self.matchers])
 
 
+@implementer(IMatcher)
 class MatchesAll(object):
     """Matches if all of the matchers it is created with match."""
 
@@ -88,6 +92,7 @@ class MismatchesAll(Mismatch):
         return '\n'.join(descriptions)
 
 
+@implementer(IMatcher)
 class Not(object):
     """Inverts a matcher."""
 
@@ -116,6 +121,7 @@ class MatchedUnexpectedly(Mismatch):
         return "%r matches %s" % (self.other, self.matcher)
 
 
+@implementer(IMatcher)
 class Annotate(object):
     """Annotates a matcher with a descriptive string.
 
@@ -167,6 +173,7 @@ class PrefixedMismatch(MismatchDecorator):
         return '%s: %s' % (self.prefix, self.original.describe())
 
 
+@implementer(IMatcher)
 class AfterPreprocessing(object):
     """Matches if the value matches after passing through a function.
 
@@ -218,6 +225,7 @@ class AfterPreprocessing(object):
 AfterPreproccessing = AfterPreprocessing
 
 
+@implementer(IMatcher)
 class AllMatch(object):
     """Matches if all provided values match the given matcher."""
 
@@ -237,6 +245,7 @@ class AllMatch(object):
             return MismatchesAll(mismatches)
 
 
+@implementer(IMatcher)
 class AnyMatch(object):
     """Matches if any of the provided values match the given matcher."""
 

--- a/testtools/matchers/_imatcher.py
+++ b/testtools/matchers/_imatcher.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2015 testtools developers. See LICENSE for details.
+
+"""Interfaces for matchers and mismatches."""
+
+
+from zope.interface import Interface
+
+
+class IMatcher(Interface):
+    """A pattern matcher, to be used with ``assertThat``."""
+
+    def match(something):
+        """Does ``something`` match this matcher?
+
+        If yes, return ``None``. Otherwise, return an ``IMismatch``.
+        """
+
+    def __str__():
+        """Get a sensible human representation of the matcher.
+
+        This should include the parameters given to the matcher and any
+        state that would affect the matches operation.
+        """
+
+
+class IMismatch(Interface):
+    """An object describing a mismatch detected by a matcher."""
+
+    def describe():
+        """Describe the mismatch.
+
+        This should be human-readable text. i.e. ``unicode`` on Python 2 or
+        ``str`` on Python 3.
+        """
+
+    def get_details():
+        """Get extra details about the mismatch.
+
+        This allows the mismatch to provide extra information beyond the basic
+        description, including large text file, binary files and debugging
+        internals.
+
+        ``assertThat`` will query ``get_details`` and attach all its values to
+        the test, permitting them to be reported in whatever manner the test
+        environment chooses.
+
+        :return: a dict mapping names to ``Content`` objects. The name is a
+            string to name the detail, and the ``Content`` object is the
+            detail to add to the result. For more information see the API to
+            which items from this dict are passed
+            ``testtools.TestCase.addDetail``.
+        """

--- a/testtools/matchers/_imatcher.py
+++ b/testtools/matchers/_imatcher.py
@@ -2,6 +2,7 @@
 
 """Interfaces for matchers and mismatches."""
 
+import warnings
 
 from zope.interface import Interface
 
@@ -31,6 +32,9 @@ class IMismatch(Interface):
 
         This should be human-readable text. i.e. ``unicode`` on Python 2 or
         ``str`` on Python 3.
+
+        In testtools 1.8.1 and prior, this was allowed to be ASCII-encoded
+        bytes, or an object castable to a string. Now, it *must* be text.
         """
 
     def get_details():
@@ -50,3 +54,11 @@ class IMismatch(Interface):
             which items from this dict are passed
             ``testtools.TestCase.addDetail``.
         """
+
+
+def _text_deprecation(obj):
+    warnings.warn(
+        'Must pass text (unicode on Python 2, str on Python 3)',
+        DeprecationWarning,
+        stacklevel=3,
+    )

--- a/testtools/matchers/_impl.py
+++ b/testtools/matchers/_impl.py
@@ -70,6 +70,8 @@ class Mismatch(object):
             to the empty dict.
         """
         if description:
+            if not isinstance(description, text):
+                _text_deprecation(description)
             self._description = description
         if details is None:
             details = {}

--- a/testtools/matchers/_impl.py
+++ b/testtools/matchers/_impl.py
@@ -17,14 +17,17 @@ __all__ = [
     'MismatchError',
     ]
 
+from zope.interface import implementer
 from testtools.compat import (
     _isbytes,
     istext,
     str_is_unicode,
     text_repr
     )
+from ._imatcher import IMatcher, IMismatch
 
 
+@implementer(IMatcher)
 class Matcher(object):
     """A pattern matcher.
 
@@ -53,6 +56,7 @@ class Matcher(object):
         raise NotImplementedError(self.__str__)
 
 
+@implementer(IMismatch)
 class Mismatch(object):
     """An object describing a mismatch detected by a Matcher."""
 
@@ -143,6 +147,7 @@ class MismatchError(AssertionError):
             return self.__unicode__().encode("ascii", "backslashreplace")
 
 
+@implementer(IMismatch)
 class MismatchDecorator(object):
     """Decorate a ``Mismatch``.
 

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2011 testtools developers. See LICENSE for details.
+# Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
 """Test case related stuff."""
 
@@ -19,7 +19,6 @@ import copy
 import functools
 import itertools
 import sys
-import types
 
 from extras import (
     safe_hasattr,
@@ -43,6 +42,8 @@ from testtools.matchers import (
     MatchesAll,
     MatchesException,
     MismatchError,
+    IMatcher,
+    IMismatch,
     Is,
     IsInstance,
     Not,
@@ -56,6 +57,7 @@ from testtools.testresult import (
     )
 
 wraps = try_import('functools.wraps')
+
 
 class TestSkipped(Exception):
     """Raised within TestCase.run() when a test is skipped."""
@@ -73,6 +75,7 @@ _UnexpectedSuccess = try_import(
     'unittest.case._UnexpectedSuccess', _UnexpectedSuccess)
 _UnexpectedSuccess = try_import(
     'unittest2.case._UnexpectedSuccess', _UnexpectedSuccess)
+
 
 class _ExpectedFailure(Exception):
     """An expected failure occured.
@@ -427,7 +430,7 @@ class TestCase(unittest.TestCase):
         """Assert that matchee is matched by matcher.
 
         :param matchee: An object to match with matcher.
-        :param matcher: An object meeting the testtools.Matcher protocol.
+        :param IMatcher matcher: The matcher to match with
         :raises MismatchError: When matcher does not match thing.
         """
         mismatch_error = self._matchHelper(matchee, matcher, message, verbose)
@@ -464,7 +467,7 @@ class TestCase(unittest.TestCase):
         has finished.
 
         :param matchee: An object to match with matcher.
-        :param matcher: An object meeting the testtools.Matcher protocol.
+        :param IMatcher matcher: The matcher to match with.
         :param message: If specified, show this message with any failed match.
         """
         mismatch_error = self._matchHelper(matchee, matcher, message, verbose)
@@ -479,10 +482,11 @@ class TestCase(unittest.TestCase):
             self.force_failure = True
 
     def _matchHelper(self, matchee, matcher, message, verbose):
-        matcher = Annotate.if_message(message, matcher)
+        matcher = Annotate.if_message(message, IMatcher(matcher, matcher))
         mismatch = matcher.match(matchee)
         if not mismatch:
             return
+        mismatch = IMismatch(mismatch, mismatch)
         for (name, value) in mismatch.get_details().items():
             self.addDetailUniqueName(name, value)
         return MismatchError(matchee, matcher, mismatch, verbose)

--- a/testtools/tests/matchers/helpers.py
+++ b/testtools/tests/matchers/helpers.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
+from testtools.matchers._imatcher import IMatcher
 from testtools.tests.helpers import FullStackRunTest
 
 
@@ -13,6 +14,13 @@ class TestMatchersInterface(object):
         # iter() and are thus mutated by other tests.
         for _, matchee, matcher in self.describe_examples:
             yield matcher.match(matchee)
+
+    def assert_matcher(self, matcher):
+        """Assert that ``matcher`` provides ``IMatcher``."""
+        self.assertEqual(
+            True, IMatcher.providedBy(self.matches_matcher),
+            'IMatcher not provided by %r' % (matcher,),
+        )
 
     def test_matches_match(self):
         matcher = self.matches_matcher
@@ -45,3 +53,7 @@ class TestMatchersInterface(object):
         for mismatch in self._iter_mismatches():
             details = mismatch.get_details()
             self.assertEqual(dict(details), details)
+
+    def test_matcher_provides_interface(self):
+        # The matcher provides the IMatcher interface.
+        self.assert_matcher(self.matches_matcher)

--- a/testtools/tests/matchers/helpers.py
+++ b/testtools/tests/matchers/helpers.py
@@ -1,11 +1,24 @@
 # Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
+import collections
 from testtools.compat import text
 from testtools.matchers._imatcher import IMatcher, IMismatch
 from testtools.tests.helpers import FullStackRunTest
 
 
 class TestMatchersInterface(object):
+    """Show that a matcher implements the matcher interface correctly.
+
+    :ivar matches_matcher: An instance of the matcher being tested.
+    :ivar matches_matches: An iterable of things that match the instance.
+    :ivar matches_mismatches: An iterable of things that do *not* match the
+        instance.
+    :ivar str_examples: An iterable of (string, matcher), where ``string`` is
+        the expected result of ``str(matcher)``.
+    :ivar describe_examples: An iterable of (text, candidate, matcher), where
+        ``text`` is the expected description of the mismatch resulting from
+        matching ``candidate`` against ``matcher``.
+    """
 
     run_tests_with = FullStackRunTest
 
@@ -26,22 +39,32 @@ class TestMatchersInterface(object):
 
     def assert_provides(self, interface, obj):
         """Assert ``obj`` provides ``interface``."""
+        # TODO: Provide a matcher for this.
         self.assertTrue(
             interface.providedBy(obj),
             '%s not provided by %r' % (interface, obj))
 
     def assert_matcher(self, matcher):
         """Assert that ``matcher`` provides ``IMatcher``."""
+        # TODO: Provide ValidMatcher() matcher that does this.
         self.assert_provides(IMatcher, matcher)
 
     def assert_mismatch(self, mismatch):
         """Assert that ``mismatch`` provides ``IMismatch``."""
+        # TODO: Provide ValidMismatch() matcher that does this.
         self.assert_provides(IMismatch, mismatch)
         description = mismatch.describe()
         self.assertTrue(
             isinstance(description, text),
             "Description is not text, is %r instead: %r" % (
                 type(description), description))
+        details = mismatch.get_details()
+        self.assertTrue(
+            isinstance(details, collections.Mapping),
+            "details are not a map, are %r instead: %r" % (
+                type(details), details))
+        # TODO: In a follow-up branch, add an interface for content, and
+        # assert that the details all implement that interface.
 
     def test_matches_match(self):
         matcher = self.matches_matcher

--- a/testtools/tests/matchers/helpers.py
+++ b/testtools/tests/matchers/helpers.py
@@ -23,19 +23,19 @@ class TestMatchersInterface(object):
         for _, matchee, matcher in self.describe_examples:
             yield matcher.match(matchee)
 
+    def assert_provides(self, interface, obj):
+        """Assert ``obj`` provides ``interface``."""
+        self.assertTrue(
+            interface.providedBy(obj),
+            '%s not provided by %r' % (interface, obj))
+
     def assert_matcher(self, matcher):
         """Assert that ``matcher`` provides ``IMatcher``."""
-        self.assertEqual(
-            True, IMatcher.providedBy(self.matches_matcher),
-            'IMatcher not provided by %r' % (matcher,),
-        )
+        self.assert_provides(IMatcher, matcher)
 
     def assert_mismatch(self, mismatch):
         """Assert that ``mismatch`` provides ``IMismatch``."""
-        self.assertEqual(
-            True, IMismatch.providedBy(mismatch),
-            'IMismatch not provided by %r' % (mismatch,),
-        )
+        self.assert_provides(IMismatch, mismatch)
 
     def test_matches_match(self):
         matcher = self.matches_matcher

--- a/testtools/tests/matchers/helpers.py
+++ b/testtools/tests/matchers/helpers.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
-from testtools.matchers._imatcher import IMatcher
+from testtools.matchers._imatcher import IMatcher, IMismatch
 from testtools.tests.helpers import FullStackRunTest
 
 
@@ -28,6 +28,13 @@ class TestMatchersInterface(object):
         self.assertEqual(
             True, IMatcher.providedBy(self.matches_matcher),
             'IMatcher not provided by %r' % (matcher,),
+        )
+
+    def assert_mismatch(self, mismatch):
+        """Assert that ``mismatch`` provides ``IMismatch``."""
+        self.assertEqual(
+            True, IMismatch.providedBy(mismatch),
+            'IMismatch not provided by %r' % (mismatch,),
         )
 
     def test_matches_match(self):
@@ -66,3 +73,8 @@ class TestMatchersInterface(object):
         # The matcher provides the IMatcher interface.
         for matcher in self._iter_matchers():
             self.assert_matcher(matcher)
+
+    def test_mismatches_provide_interface(self):
+        # Mismatches provide the IMismatch interface.
+        for mismatch in self._iter_mismatches():
+            self.assert_mismatch(mismatch)

--- a/testtools/tests/matchers/helpers.py
+++ b/testtools/tests/matchers/helpers.py
@@ -8,6 +8,14 @@ class TestMatchersInterface(object):
 
     run_tests_with = FullStackRunTest
 
+    def _iter_matchers(self):
+        """Iterate through matchers from the sample data."""
+        yield self.matches_matcher
+        for _, matcher in self.str_examples:
+            yield matcher
+        for _, _, matcher in self.describe_examples:
+            yield matcher
+
     def _iter_mismatches(self):
         """Iterate through mismatches from the sample data."""
         # Don't iterate through matches_mismatches, because sometimes they are
@@ -56,4 +64,5 @@ class TestMatchersInterface(object):
 
     def test_matcher_provides_interface(self):
         # The matcher provides the IMatcher interface.
-        self.assert_matcher(self.matches_matcher)
+        for matcher in self._iter_matchers():
+            self.assert_matcher(matcher)

--- a/testtools/tests/matchers/helpers.py
+++ b/testtools/tests/matchers/helpers.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
+from testtools.compat import text
 from testtools.matchers._imatcher import IMatcher, IMismatch
 from testtools.tests.helpers import FullStackRunTest
 
@@ -36,6 +37,11 @@ class TestMatchersInterface(object):
     def assert_mismatch(self, mismatch):
         """Assert that ``mismatch`` provides ``IMismatch``."""
         self.assert_provides(IMismatch, mismatch)
+        description = mismatch.describe()
+        self.assertTrue(
+            isinstance(description, text),
+            "Description is not text, is %r instead: %r" % (
+                type(description), description))
 
     def test_matches_match(self):
         matcher = self.matches_matcher

--- a/testtools/tests/matchers/helpers.py
+++ b/testtools/tests/matchers/helpers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
 from testtools.tests.helpers import FullStackRunTest
 
@@ -6,6 +6,13 @@ from testtools.tests.helpers import FullStackRunTest
 class TestMatchersInterface(object):
 
     run_tests_with = FullStackRunTest
+
+    def _iter_mismatches(self):
+        """Iterate through mismatches from the sample data."""
+        # Don't iterate through matches_mismatches, because sometimes they are
+        # iter() and are thus mutated by other tests.
+        for _, matchee, matcher in self.describe_examples:
+            yield matcher.match(matchee)
 
     def test_matches_match(self):
         matcher = self.matches_matcher
@@ -35,8 +42,6 @@ class TestMatchersInterface(object):
     def test_mismatch_details(self):
         # The mismatch object must provide get_details, which must return a
         # dictionary mapping names to Content objects.
-        examples = self.describe_examples
-        for difference, matchee, matcher in examples:
-            mismatch = matcher.match(matchee)
+        for mismatch in self._iter_mismatches():
             details = mismatch.get_details()
             self.assertEqual(dict(details), details)

--- a/testtools/tests/matchers/test_basic.py
+++ b/testtools/tests/matchers/test_basic.py
@@ -100,7 +100,7 @@ class TestEqualsInterface(TestCase, TestMatchersInterface):
 
     str_examples = [("Equals(1)", Equals(1)), ("Equals('1')", Equals('1'))]
 
-    describe_examples = [("1 != 2", 2, Equals(1))]
+    describe_examples = [(_u("1 != 2"), 2, Equals(1))]
 
 
 class TestNotEqualsInterface(TestCase, TestMatchersInterface):
@@ -112,7 +112,7 @@ class TestNotEqualsInterface(TestCase, TestMatchersInterface):
     str_examples = [
         ("NotEquals(1)", NotEquals(1)), ("NotEquals('1')", NotEquals('1'))]
 
-    describe_examples = [("1 == 1", 1, NotEquals(1))]
+    describe_examples = [(_u("1 == 1"), 1, NotEquals(1))]
 
 
 class TestIsInterface(TestCase, TestMatchersInterface):
@@ -131,22 +131,23 @@ class TestIsInterface(TestCase, TestMatchersInterface):
 
 class TestIsInstanceInterface(TestCase, TestMatchersInterface):
 
-    class Foo:pass
+    class Foo:
+        pass
 
     matches_matcher = IsInstance(Foo)
     matches_matches = [Foo()]
     matches_mismatches = [object(), 1, Foo]
 
     str_examples = [
-            ("IsInstance(str)", IsInstance(str)),
-            ("IsInstance(str, int)", IsInstance(str, int)),
-            ]
+        ("IsInstance(str)", IsInstance(str)),
+        ("IsInstance(str, int)", IsInstance(str, int)),
+    ]
 
     describe_examples = [
-            ("'foo' is not an instance of int", 'foo', IsInstance(int)),
-            ("'foo' is not an instance of any of (int, type)", 'foo',
-             IsInstance(int, type)),
-            ]
+        (_u("'foo' is not an instance of int"), 'foo', IsInstance(int)),
+        (_u("'foo' is not an instance of any of (int, type)"), 'foo',
+         IsInstance(int, type)),
+    ]
 
 
 class TestLessThanInterface(TestCase, TestMatchersInterface):
@@ -160,8 +161,8 @@ class TestLessThanInterface(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ('4 is not > 5', 5, LessThan(4)),
-        ('4 is not > 4', 4, LessThan(4)),
+        (_u('4 is not > 5'), 5, LessThan(4)),
+        (_u('4 is not > 4'), 4, LessThan(4)),
         ]
 
 
@@ -176,8 +177,8 @@ class TestGreaterThanInterface(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ('5 is not < 4', 4, GreaterThan(5)),
-        ('4 is not < 4', 4, GreaterThan(4)),
+        (_u('5 is not < 4'), 4, GreaterThan(5)),
+        (_u('4 is not < 4'), 4, GreaterThan(4)),
         ]
 
 
@@ -192,7 +193,7 @@ class TestContainsInterface(TestCase, TestMatchersInterface):
         ("Contains('foo')", Contains('foo')),
         ]
 
-    describe_examples = [("1 not in 2", 2, Contains(1))]
+    describe_examples = [(_u("1 not in 2"), 2, Contains(1))]
 
 
 class DoesNotStartWithTests(TestCase):
@@ -215,7 +216,8 @@ class DoesNotStartWithTests(TestCase):
         string = _b("A\xA7")
         suffix = _b("B\xA7")
         mismatch = DoesNotStartWith(string, suffix)
-        self.assertEqual("%r does not start with %r." % (string, suffix),
+        self.assertEqual(
+            _u("%r does not start with %r.") % (string, suffix),
             mismatch.describe())
 
 
@@ -276,7 +278,8 @@ class DoesNotEndWithTests(TestCase):
         string = _b("A\xA7")
         suffix = _b("B\xA7")
         mismatch = DoesNotEndWith(string, suffix)
-        self.assertEqual("%r does not end with %r." % (string, suffix),
+        self.assertEqual(
+            _u("%r does not end with %r.") % (string, suffix),
             mismatch.describe())
 
 
@@ -333,19 +336,18 @@ class TestSameMembers(TestCase, TestMatchersInterface):
         'foo',
         ]
 
-    describe_examples = [
-        (("elements differ:\n"
-          "reference = ['apple', 'orange', 'canteloupe', 'watermelon', 'lemon', 'banana']\n"
-          "actual    = ['orange', 'apple', 'banana', 'sparrow', 'lemon', 'canteloupe']\n"
-          ": \n"
-          "missing:    ['watermelon']\n"
-          "extra:      ['sparrow']"
-          ),
-         ['orange', 'apple', 'banana', 'sparrow', 'lemon', 'canteloupe',],
-         SameMembers(
-             ['apple', 'orange', 'canteloupe', 'watermelon',
-              'lemon', 'banana',])),
-        ]
+    describe_examples = [(
+        (_u("elements differ:\n"
+            "reference = ['apple', 'orange', 'canteloupe', 'watermelon', 'lemon', 'banana']\n"
+            "actual    = ['orange', 'apple', 'banana', 'sparrow', 'lemon', 'canteloupe']\n"
+            ": \n"
+            "missing:    ['watermelon']\n"
+            "extra:      ['sparrow']")),
+        ['orange', 'apple', 'banana', 'sparrow', 'lemon', 'canteloupe'],
+        SameMembers(
+            ['apple', 'orange', 'canteloupe', 'watermelon',
+             'lemon', 'banana'])),
+    ]
 
     str_examples = [
         ('SameMembers([1, 2, 3])', SameMembers([1, 2, 3])),
@@ -367,11 +369,11 @@ class TestMatchesRegex(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ("'c' does not match /a|b/", 'c', MatchesRegex('a|b')),
-        ("'c' does not match /a\d/", 'c', MatchesRegex(r'a\d')),
-        ("%r does not match /\\s+\\xa7/" % (_b('c'),),
+        (_u("'c' does not match /a|b/"), 'c', MatchesRegex('a|b')),
+        (_u("'c' does not match /a\d/"), 'c', MatchesRegex(r'a\d')),
+        (_u("%r does not match /\\s+\\xa7/") % (_b('c'),),
             _b('c'), MatchesRegex(_b("\\s+\xA7"))),
-        ("%r does not match /\\s+\\xa7/" % (_u('c'),),
+        (_u("%r does not match /\\s+\\xa7/") % (_u('c'),),
             _u('c'), MatchesRegex(_u("\\s+\xA7"))),
         ]
 
@@ -387,7 +389,7 @@ class TestHasLength(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ("len([]) != 1", [], HasLength(1)),
+        (_u("len([]) != 1"), [], HasLength(1)),
         ]
 
 

--- a/testtools/tests/matchers/test_basic.py
+++ b/testtools/tests/matchers/test_basic.py
@@ -125,8 +125,8 @@ class TestEqualsInterface(TestCase, TestMatchersInterface):
         (_u("!=:\n"
             "reference = 'abcdefghijklmnopqrstuvwxyz0123456789'\n"
             "actual    = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'\n"),
-         _u('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'),
-         Equals(_u('abcdefghijklmnopqrstuvwxyz0123456789'))),
+         'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+         Equals('abcdefghijklmnopqrstuvwxyz0123456789')),
     ]
 
 

--- a/testtools/tests/matchers/test_datastructures.py
+++ b/testtools/tests/matchers/test_datastructures.py
@@ -1,11 +1,11 @@
-# Copyright (c) 2008-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
 import doctest
 import re
 import sys
 
 from testtools import TestCase
-from testtools.compat import StringIO
+from testtools.compat import StringIO, _u
 from testtools.matchers import (
     Annotate,
     Equals,
@@ -67,19 +67,19 @@ class TestMatchesStructure(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ("""\
+        (_u("""\
 Differences: [
 3 != 1: x
-]""", SimpleClass(1, 2), MatchesStructure(x=Equals(3), y=Equals(2))),
-        ("""\
+]"""), SimpleClass(1, 2), MatchesStructure(x=Equals(3), y=Equals(2))),
+        (_u("""\
 Differences: [
 3 != 2: y
-]""", SimpleClass(1, 2), MatchesStructure(x=Equals(1), y=Equals(3))),
-        ("""\
+]"""), SimpleClass(1, 2), MatchesStructure(x=Equals(1), y=Equals(3))),
+        (_u("""\
 Differences: [
 0 != 1: x
 0 != 2: y
-]""", SimpleClass(1, 2), MatchesStructure(x=Equals(0), y=Equals(0))),
+]"""), SimpleClass(1, 2), MatchesStructure(x=Equals(0), y=Equals(0))),
         ]
 
     def test_fromExample(self):
@@ -122,7 +122,7 @@ class TestMatchesSetwise(TestCase):
         self.assertThat(
             actual_description,
             Annotate(
-                "%s matching %s" % (matcher, value),
+                _u("%s matching %s") % (matcher, value),
                 description_matcher))
 
     def test_matches(self):
@@ -198,9 +198,9 @@ class TestContainsAllInterface(TestCase, TestMatchersInterface):
         ContainsAll(['foo', 'bar'])),
         ]
 
-    describe_examples = [("""Differences: [
+    describe_examples = [(_u("""Differences: [
 'baz' not in 'foo'
-]""",
+]"""),
     'foo', ContainsAll(['foo', 'baz']))]
 
 

--- a/testtools/tests/matchers/test_dict.py
+++ b/testtools/tests/matchers/test_dict.py
@@ -1,4 +1,5 @@
 from testtools import TestCase
+from testtools.compat import _u
 from testtools.matchers import (
     Equals,
     NotEquals,
@@ -26,7 +27,7 @@ class TestMatchesAllDictInterface(TestCase, TestMatchersInterface):
          matches_matcher)]
 
     describe_examples = [
-        ("""a: 1 == 1""", 1, matches_matcher),
+        (_u("""a: 1 == 1"""), 1, matches_matcher),
         ]
 
 
@@ -107,30 +108,30 @@ class TestMatchesDict(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ("Missing: {\n"
-         "  'baz': Not(Equals('qux')),\n"
-         "  'foo': Equals('bar'),\n"
-         "}",
+        (_u("Missing: {\n"
+            "  'baz': Not(Equals('qux')),\n"
+            "  'foo': Equals('bar'),\n"
+            "}"),
          {}, matches_matcher),
-        ("Differences: {\n"
-         "  'baz': 'qux' matches Equals('qux'),\n"
-         "}",
+        (_u("Differences: {\n"
+            "  'baz': 'qux' matches Equals('qux'),\n"
+            "}"),
          {'foo': 'bar', 'baz': 'qux'}, matches_matcher),
-        ("Differences: {\n"
-         "  'baz': 'qux' matches Equals('qux'),\n"
-         "  'foo': 'bar' != 'bop',\n"
-         "}",
+        (_u("Differences: {\n"
+            "  'baz': 'qux' matches Equals('qux'),\n"
+            "  'foo': 'bar' != 'bop',\n"
+            "}"),
          {'foo': 'bop', 'baz': 'qux'}, matches_matcher),
-        ("Extra: {\n"
-         "  'cat': 'dog',\n"
-         "}",
+        (_u("Extra: {\n"
+            "  'cat': 'dog',\n"
+            "}"),
          {'foo': 'bar', 'baz': 'quux', 'cat': 'dog'}, matches_matcher),
-        ("Extra: {\n"
-         "  'cat': 'dog',\n"
-         "}\n"
-         "Missing: {\n"
-         "  'baz': Not(Equals('qux')),\n"
-         "}",
+        (_u("Extra: {\n"
+            "  'cat': 'dog',\n"
+            "}\n"
+            "Missing: {\n"
+            "  'baz': Not(Equals('qux')),\n"
+            "}"),
          {'foo': 'bar', 'cat': 'dog'}, matches_matcher),
         ]
 
@@ -160,23 +161,23 @@ class TestContainsDict(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ("Missing: {\n"
-         "  'baz': Not(Equals('qux')),\n"
-         "  'foo': Equals('bar'),\n"
-         "}",
+        (_u("Missing: {\n"
+            "  'baz': Not(Equals('qux')),\n"
+            "  'foo': Equals('bar'),\n"
+            "}"),
          {}, matches_matcher),
-        ("Differences: {\n"
-         "  'baz': 'qux' matches Equals('qux'),\n"
-         "}",
+        (_u("Differences: {\n"
+            "  'baz': 'qux' matches Equals('qux'),\n"
+            "}"),
          {'foo': 'bar', 'baz': 'qux'}, matches_matcher),
-        ("Differences: {\n"
-         "  'baz': 'qux' matches Equals('qux'),\n"
-         "  'foo': 'bar' != 'bop',\n"
-         "}",
+        (_u("Differences: {\n"
+            "  'baz': 'qux' matches Equals('qux'),\n"
+            "  'foo': 'bar' != 'bop',\n"
+            "}"),
          {'foo': 'bop', 'baz': 'qux'}, matches_matcher),
-        ("Missing: {\n"
-         "  'baz': Not(Equals('qux')),\n"
-         "}",
+        (_u("Missing: {\n"
+            "  'baz': Not(Equals('qux')),\n"
+            "}"),
          {'foo': 'bar', 'cat': 'dog'}, matches_matcher),
         ]
 
@@ -201,23 +202,23 @@ class TestContainedByDict(TestCase, TestMatchersInterface):
 
     str_examples = [
         ("ContainedByDict({'baz': %s, 'foo': %s})" % (
-                Not(Equals('qux')), Equals('bar')),
+            Not(Equals('qux')), Equals('bar')),
          matches_matcher),
         ]
 
     describe_examples = [
-        ("Differences: {\n"
-         "  'baz': 'qux' matches Equals('qux'),\n"
-         "}",
+        (_u("Differences: {\n"
+            "  'baz': 'qux' matches Equals('qux'),\n"
+            "}"),
          {'foo': 'bar', 'baz': 'qux'}, matches_matcher),
-        ("Differences: {\n"
-         "  'baz': 'qux' matches Equals('qux'),\n"
-         "  'foo': 'bar' != 'bop',\n"
-         "}",
+        (_u("Differences: {\n"
+            "  'baz': 'qux' matches Equals('qux'),\n"
+            "  'foo': 'bar' != 'bop',\n"
+            "}"),
          {'foo': 'bop', 'baz': 'qux'}, matches_matcher),
-        ("Extra: {\n"
-         "  'cat': 'dog',\n"
-         "}",
+        (_u("Extra: {\n"
+            "  'cat': 'dog',\n"
+            "}"),
          {'foo': 'bar', 'cat': 'dog'}, matches_matcher),
         ]
 

--- a/testtools/tests/matchers/test_doctest.py
+++ b/testtools/tests/matchers/test_doctest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
 import doctest
 
@@ -13,21 +13,24 @@ from testtools.tests.helpers import FullStackRunTest
 from testtools.tests.matchers.helpers import TestMatchersInterface
 
 
-
 class TestDocTestMatchesInterface(TestCase, TestMatchersInterface):
 
     matches_matcher = DocTestMatches("Ran 1 test in ...s", doctest.ELLIPSIS)
     matches_matches = ["Ran 1 test in 0.000s", "Ran 1 test in 1.234s"]
     matches_mismatches = ["Ran 1 tests in 0.000s", "Ran 2 test in 0.000s"]
 
-    str_examples = [("DocTestMatches('Ran 1 test in ...s\\n')",
-        DocTestMatches("Ran 1 test in ...s")),
+    str_examples = [
+        ("DocTestMatches('Ran 1 test in ...s\\n')",
+         DocTestMatches("Ran 1 test in ...s")),
         ("DocTestMatches('foo\\n', flags=8)", DocTestMatches("foo", flags=8)),
-        ]
+    ]
 
-    describe_examples = [('Expected:\n    Ran 1 tests in ...s\nGot:\n'
-        '    Ran 1 test in 0.123s\n', "Ran 1 test in 0.123s",
-        DocTestMatches("Ran 1 tests in ...s", doctest.ELLIPSIS))]
+    describe_examples = [(
+        _u('Expected:\n    Ran 1 tests in ...s\nGot:\n'
+           '    Ran 1 test in 0.123s\n'),
+        "Ran 1 test in 0.123s",
+        DocTestMatches("Ran 1 tests in ...s", doctest.ELLIPSIS))
+    ]
 
 
 class TestDocTestMatchesInterfaceUnicode(TestCase, TestMatchersInterface):
@@ -36,9 +39,10 @@ class TestDocTestMatchesInterfaceUnicode(TestCase, TestMatchersInterface):
     matches_matches = [_u("\xa7"), _u("\xa7 more\n")]
     matches_mismatches = ["\\xa7", _u("more \xa7"), _u("\n\xa7")]
 
-    str_examples = [("DocTestMatches(%r)" % (_u("\xa7\n"),),
-        DocTestMatches(_u("\xa7"))),
-        ]
+    str_examples = [
+        ("DocTestMatches(%r)" % (_u("\xa7\n"),),
+         DocTestMatches(_u("\xa7"))),
+    ]
 
     describe_examples = [(
         _u("Expected:\n    \xa7\nGot:\n    a\n"),
@@ -68,7 +72,8 @@ class TestDocTestMatchesSpecific(TestCase):
         """
         header = _b("\x89PNG\r\n\x1a\n...")
         if str_is_unicode:
-            self.assertRaises(TypeError,
+            self.assertRaises(
+                TypeError,
                 DocTestMatches, header, doctest.ELLIPSIS)
             return
         matcher = DocTestMatches(header, doctest.ELLIPSIS)

--- a/testtools/tests/matchers/test_exception.py
+++ b/testtools/tests/matchers/test_exception.py
@@ -3,6 +3,7 @@
 import sys
 
 from testtools import TestCase
+from testtools.compat import _u
 from testtools.matchers import (
     AfterPreprocessing,
     Equals,
@@ -37,10 +38,10 @@ class TestMatchesExceptionInstanceInterface(TestCase, TestMatchersInterface):
          MatchesException(Exception('foo')))
         ]
     describe_examples = [
-        ("%r is not a %r" % (Exception, ValueError),
+        (_u("%r is not a %r") % (Exception, ValueError),
          error_base_foo,
          MatchesException(ValueError("foo"))),
-        ("ValueError('bar',) has different arguments to ValueError('foo',).",
+        (_u("ValueError('bar',) has different arguments to ValueError('foo',)."),
          error_bar,
          MatchesException(ValueError("foo"))),
         ]
@@ -60,7 +61,7 @@ class TestMatchesExceptionTypeInterface(TestCase, TestMatchersInterface):
          MatchesException(Exception))
         ]
     describe_examples = [
-        ("%r is not a %r" % (Exception, ValueError),
+        (_u("%r is not a %r") % (Exception, ValueError),
          error_base_foo,
          MatchesException(ValueError)),
         ]
@@ -80,7 +81,7 @@ class TestMatchesExceptionTypeReInterface(TestCase, TestMatchersInterface):
          MatchesException(Exception, 'fo.'))
         ]
     describe_examples = [
-        ("'bar' does not match /fo./",
+        (_u("'bar' does not match /fo./"),
          error_bar, MatchesException(ValueError, "fo.")),
         ]
 
@@ -100,7 +101,7 @@ class TestMatchesExceptionTypeMatcherInterface(TestCase, TestMatchersInterface):
          MatchesException(Exception, Equals('foo')))
         ]
     describe_examples = [
-        ("5 != %r" % (error_bar[1],),
+        (_u("5 != %r") % (error_bar[1],),
          error_bar, MatchesException(ValueError, Equals(5))),
         ]
 

--- a/testtools/tests/matchers/test_filesystem.py
+++ b/testtools/tests/matchers/test_filesystem.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
 import os
 import shutil
@@ -6,6 +6,7 @@ import tarfile
 import tempfile
 
 from testtools import TestCase
+from testtools.compat import _u
 from testtools.matchers import (
     Contains,
     DocTestMatches,
@@ -51,7 +52,8 @@ class TestPathExists(TestCase, PathHelpers):
         doesntexist = os.path.join(self.mkdtemp(), 'doesntexist')
         mismatch = PathExists().match(doesntexist)
         self.assertThat(
-            "%s does not exist." % doesntexist, Equals(mismatch.describe()))
+            _u("%s does not exist.") % doesntexist,
+            Equals(mismatch.describe()))
 
 
 class TestDirExists(TestCase, PathHelpers):
@@ -72,7 +74,8 @@ class TestDirExists(TestCase, PathHelpers):
         self.touch(filename)
         mismatch = DirExists().match(filename)
         self.assertThat(
-            "%s is not a directory." % filename, Equals(mismatch.describe()))
+            _u("%s is not a directory.") % filename,
+            Equals(mismatch.describe()))
 
 
 class TestFileExists(TestCase, PathHelpers):
@@ -94,7 +97,7 @@ class TestFileExists(TestCase, PathHelpers):
         tempdir = self.mkdtemp()
         mismatch = FileExists().match(tempdir)
         self.assertThat(
-            "%s is not a file." % tempdir, Equals(mismatch.describe()))
+            _u("%s is not a file.") % tempdir, Equals(mismatch.describe()))
 
 
 class TestDirContains(TestCase, PathHelpers):
@@ -175,6 +178,8 @@ class TestFileContains(TestCase, PathHelpers):
         self.assertThat(
             Equals('Hello World!').match('Goodbye Cruel World!').describe(),
             Equals(mismatch.describe()))
+
+
 class TestTarballContains(TestCase, PathHelpers):
 
     def test_match(self):

--- a/testtools/tests/matchers/test_filesystem.py
+++ b/testtools/tests/matchers/test_filesystem.py
@@ -254,9 +254,9 @@ class TestHasPermissions(TestCase, PathHelpers, TestMatchersInterface):
 
         tempdir = self.mkdtemp()
         file1 = self.touch(os.path.join(tempdir, 'file1'))
-        os.chmod(file1, 0777)
+        os.chmod(file1, int('0777', 8))
         file2 = self.touch(os.path.join(tempdir, 'file2'))
-        os.chmod(file2, 0644)
+        os.chmod(file2, int('0644', 8))
 
         self.matches_matcher = HasPermissions('0777')
         self.matches_matches = [file1]

--- a/testtools/tests/matchers/test_filesystem.py
+++ b/testtools/tests/matchers/test_filesystem.py
@@ -22,6 +22,7 @@ from testtools.matchers._filesystem import (
     SamePath,
     TarballContains,
     )
+from .helpers import TestMatchersInterface
 
 
 class PathHelpers(object):
@@ -37,87 +38,93 @@ class PathHelpers(object):
             fp.write(contents)
         finally:
             fp.close()
+        self.addCleanup(os.unlink, filename)
+        return filename
 
     def touch(self, filename):
         return self.create_file(filename)
 
 
-class TestPathExists(TestCase, PathHelpers):
+class TestPathExists(TestCase, PathHelpers, TestMatchersInterface):
 
-    def test_exists(self):
-        tempdir = self.mkdtemp()
-        self.assertThat(tempdir, PathExists())
+    def setUp(self):
+        super(TestPathExists, self).setUp()
+        existing_path = self.mkdtemp()
+        nonexisting_path = os.path.join(existing_path, 'doesntexist')
 
-    def test_not_exists(self):
-        doesntexist = os.path.join(self.mkdtemp(), 'doesntexist')
-        mismatch = PathExists().match(doesntexist)
-        self.assertThat(
-            _u("%s does not exist.") % doesntexist,
-            Equals(mismatch.describe()))
-
-
-class TestDirExists(TestCase, PathHelpers):
-
-    def test_exists(self):
-        tempdir = self.mkdtemp()
-        self.assertThat(tempdir, DirExists())
-
-    def test_not_exists(self):
-        doesntexist = os.path.join(self.mkdtemp(), 'doesntexist')
-        mismatch = DirExists().match(doesntexist)
-        self.assertThat(
-            PathExists().match(doesntexist).describe(),
-            Equals(mismatch.describe()))
-
-    def test_not_a_directory(self):
-        filename = os.path.join(self.mkdtemp(), 'foo')
-        self.touch(filename)
-        mismatch = DirExists().match(filename)
-        self.assertThat(
-            _u("%s is not a directory.") % filename,
-            Equals(mismatch.describe()))
+        self.matches_matcher = PathExists()
+        self.matches_matches = [existing_path]
+        self.matches_mismatches = [nonexisting_path]
+        self.str_examples = []
+        self.describe_examples = [
+            (_u("%s does not exist.") % nonexisting_path,
+             nonexisting_path, PathExists()),
+        ]
 
 
-class TestFileExists(TestCase, PathHelpers):
+class TestDirExists(TestCase, PathHelpers, TestMatchersInterface):
 
-    def test_exists(self):
-        tempdir = self.mkdtemp()
-        filename = os.path.join(tempdir, 'filename')
-        self.touch(filename)
-        self.assertThat(filename, FileExists())
+    def setUp(self):
+        super(TestDirExists, self).setUp()
+        existing_dir = self.mkdtemp()
+        nonexisting_path = os.path.join(existing_dir, 'doesntexist')
+        existing_file = self.touch(os.path.join(existing_dir, 'file'))
 
-    def test_not_exists(self):
-        doesntexist = os.path.join(self.mkdtemp(), 'doesntexist')
-        mismatch = FileExists().match(doesntexist)
-        self.assertThat(
-            PathExists().match(doesntexist).describe(),
-            Equals(mismatch.describe()))
-
-    def test_not_a_file(self):
-        tempdir = self.mkdtemp()
-        mismatch = FileExists().match(tempdir)
-        self.assertThat(
-            _u("%s is not a file.") % tempdir, Equals(mismatch.describe()))
+        self.matches_matcher = DirExists()
+        self.matches_matches = [existing_dir]
+        self.matches_mismatches = [nonexisting_path, existing_file]
+        self.str_examples = []
+        self.describe_examples = [
+            (PathExists().match(nonexisting_path).describe(),
+             nonexisting_path, DirExists()),
+            (_u("%s is not a directory.") % existing_file,
+             existing_file, DirExists()),
+        ]
 
 
-class TestDirContains(TestCase, PathHelpers):
+class TestFileExists(TestCase, PathHelpers, TestMatchersInterface):
+
+    def setUp(self):
+        super(TestFileExists, self).setUp()
+        existing_dir = self.mkdtemp()
+        nonexisting_path = os.path.join(existing_dir, 'doesntexist')
+        existing_file = self.touch(os.path.join(existing_dir, 'file'))
+
+        self.matches_matcher = FileExists()
+        self.matches_matches = [existing_file]
+        self.matches_mismatches = [nonexisting_path, existing_dir]
+        self.str_examples = []
+        self.describe_examples = [
+            (PathExists().match(nonexisting_path).describe(),
+             nonexisting_path, FileExists()),
+            (_u("%s is not a file.") % existing_dir,
+             existing_dir, FileExists()),
+        ]
+
+
+class TestDirContains(TestCase, PathHelpers, TestMatchersInterface):
+
+    def setUp(self):
+        super(TestDirContains, self).setUp()
+        existing_dir = self.mkdtemp()
+        nonexisting_path = os.path.join(existing_dir, 'doesntexist')
+        foo = self.touch(os.path.join(existing_dir, 'foo'))
+        bar = self.touch(os.path.join(existing_dir, 'bar'))
+
+        self.matches_matcher = DirContains(['foo', 'bar'])
+        self.matches_matches = [existing_dir]
+        self.matches_mismatches = [nonexisting_path, foo, bar]
+        self.str_examples = []
+        self.describe_examples = [
+            (PathExists().match(nonexisting_path).describe(),
+             nonexisting_path, DirContains([])),
+            (_u("%s is not a directory.") % (foo,),
+             foo, DirContains([])),
+        ]
 
     def test_empty(self):
         tempdir = self.mkdtemp()
         self.assertThat(tempdir, DirContains([]))
-
-    def test_not_exists(self):
-        doesntexist = os.path.join(self.mkdtemp(), 'doesntexist')
-        mismatch = DirContains([]).match(doesntexist)
-        self.assertThat(
-            PathExists().match(doesntexist).describe(),
-            Equals(mismatch.describe()))
-
-    def test_contains_files(self):
-        tempdir = self.mkdtemp()
-        self.touch(os.path.join(tempdir, 'foo'))
-        self.touch(os.path.join(tempdir, 'bar'))
-        self.assertThat(tempdir, DirContains(['bar', 'foo']))
 
     def test_matcher(self):
         tempdir = self.mkdtemp()
@@ -141,20 +148,26 @@ class TestDirContains(TestCase, PathHelpers):
             Equals(mismatch.describe()))
 
 
-class TestFileContains(TestCase, PathHelpers):
+class TestFileContains(TestCase, PathHelpers, TestMatchersInterface):
 
-    def test_not_exists(self):
-        doesntexist = os.path.join(self.mkdtemp(), 'doesntexist')
-        mismatch = FileContains('').match(doesntexist)
-        self.assertThat(
-            PathExists().match(doesntexist).describe(),
-            Equals(mismatch.describe()))
-
-    def test_contains(self):
+    def setUp(self):
+        super(TestFileContains, self).setUp()
         tempdir = self.mkdtemp()
-        filename = os.path.join(tempdir, 'foo')
-        self.create_file(filename, 'Hello World!')
-        self.assertThat(filename, FileContains('Hello World!'))
+        nonexisting_path = os.path.join(tempdir, 'doesntexist')
+        filepath = self.create_file(
+            os.path.join(tempdir, 'foo'), 'Hello World!')
+        empty = self.touch(os.path.join(tempdir, 'bar'))
+
+        self.matches_matcher = FileContains('Hello World!')
+        self.matches_matches = [filepath]
+        self.matches_mismatches = [nonexisting_path, empty]
+        self.str_examples = []
+        self.describe_examples = [
+            (PathExists().match(nonexisting_path).describe(),
+             nonexisting_path, FileContains('')),
+            (Equals('Hello World!').match('').describe(),
+             empty, FileContains('Hello World!')),
+        ]
 
     def test_matcher(self):
         tempdir = self.mkdtemp()
@@ -170,46 +183,47 @@ class TestFileContains(TestCase, PathHelpers):
         self.assertRaises(
             AssertionError, FileContains, contents=[], matcher=Contains('a'))
 
-    def test_does_not_contain(self):
+
+class TestTarballContains(TestCase, PathHelpers, TestMatchersInterface):
+
+    def setUp(self):
+        super(TestTarballContains, self).setUp()
+        tarball_a = self._make_tarball(['a', 'b'])
+        tarball_b = self._make_tarball(['c', 'd'])
+
+        self.matches_matcher = TarballContains(['a', 'b'])
+        self.matches_matches = [tarball_a]
+        self.matches_mismatches = [tarball_b]
+        self.str_examples = []
+        self.describe_examples = [
+            (Equals(['c', 'd']).match(['a', 'b']).describe(),
+             tarball_a, TarballContains(['c', 'd'])),
+        ]
+
+    def _make_tarball(self, files):
         tempdir = self.mkdtemp()
-        filename = os.path.join(tempdir, 'foo')
-        self.create_file(filename, 'Goodbye Cruel World!')
-        mismatch = FileContains('Hello World!').match(filename)
-        self.assertThat(
-            Equals('Hello World!').match('Goodbye Cruel World!').describe(),
-            Equals(mismatch.describe()))
-
-
-class TestTarballContains(TestCase, PathHelpers):
-
-    def test_match(self):
-        tempdir = self.mkdtemp()
-        in_temp_dir = lambda x: os.path.join(tempdir, x)
-        self.touch(in_temp_dir('a'))
-        self.touch(in_temp_dir('b'))
-        tarball = tarfile.open(in_temp_dir('foo.tar.gz'), 'w')
-        tarball.add(in_temp_dir('a'), 'a')
-        tarball.add(in_temp_dir('b'), 'b')
+        abs_files = [os.path.join(tempdir, filename) for filename in files]
+        for filename in abs_files:
+            self.touch(filename)
+        new_tmpdir = self.mkdtemp()
+        tar_path = os.path.join(new_tmpdir, 'foo.tar.gz')
+        tarball = tarfile.open(tar_path, 'w')
+        for filename, base in zip(abs_files, files):
+            tarball.add(filename, base)
         tarball.close()
-        self.assertThat(
-            in_temp_dir('foo.tar.gz'), TarballContains(['b', 'a']))
-
-    def test_mismatch(self):
-        tempdir = self.mkdtemp()
-        in_temp_dir = lambda x: os.path.join(tempdir, x)
-        self.touch(in_temp_dir('a'))
-        self.touch(in_temp_dir('b'))
-        tarball = tarfile.open(in_temp_dir('foo.tar.gz'), 'w')
-        tarball.add(in_temp_dir('a'), 'a')
-        tarball.add(in_temp_dir('b'), 'b')
-        tarball.close()
-        mismatch = TarballContains(['d', 'c']).match(in_temp_dir('foo.tar.gz'))
-        self.assertEqual(
-            mismatch.describe(),
-            Equals(['c', 'd']).match(['a', 'b']).describe())
+        return tar_path
 
 
-class TestSamePath(TestCase, PathHelpers):
+class TestSamePath(TestCase, PathHelpers, TestMatchersInterface):
+
+    def setUp(self):
+        super(TestSamePath, self).setUp()
+        self.matches_matcher = SamePath('foo')
+        self.matches_matches = [
+            'foo', 'foo/../foo', 'foo/bar/../', os.path.abspath('foo')]
+        self.matches_mismatches = ['bar']
+        self.str_examples = []
+        self.describe_examples = []
 
     def test_same_string(self):
         self.assertThat('foo', SamePath('foo'))
@@ -233,7 +247,25 @@ class TestSamePath(TestCase, PathHelpers):
         self.assertThat(target, SamePath(source))
 
 
-class TestHasPermissions(TestCase, PathHelpers):
+class TestHasPermissions(TestCase, PathHelpers, TestMatchersInterface):
+
+    def setUp(self):
+        super(TestHasPermissions, self).setUp()
+
+        tempdir = self.mkdtemp()
+        file1 = self.touch(os.path.join(tempdir, 'file1'))
+        os.chmod(file1, 0777)
+        file2 = self.touch(os.path.join(tempdir, 'file2'))
+        os.chmod(file2, 0644)
+
+        self.matches_matcher = HasPermissions('0777')
+        self.matches_matches = [file1]
+        self.matches_mismatches = [file2]
+        self.str_examples = []
+        self.describe_examples = [
+            (Equals('0777').match('0644').describe(),
+             file2, HasPermissions('0777')),
+        ]
 
     def test_match(self):
         tempdir = self.mkdtemp()

--- a/testtools/tests/matchers/test_higherorder.py
+++ b/testtools/tests/matchers/test_higherorder.py
@@ -1,6 +1,7 @@
-# Copyright (c) 2008-2011 testtools developers. See LICENSE for details.
+# Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
 from testtools import TestCase
+from testtools.compat import _u
 from testtools.matchers import (
     DocTestMatches,
     Equals,
@@ -104,6 +105,7 @@ class TestAfterPreprocessing(TestCase, TestMatchersInterface):
         ("1 != 0", 2,
          AfterPreprocessing(parity, Equals(1), annotate=False)),
         ]
+
 
 class TestMatchersAnyInterface(TestCase, TestMatchersInterface):
 
@@ -209,17 +211,17 @@ def is_even(x):
 
 class TestMatchesPredicate(TestCase, TestMatchersInterface):
 
-    matches_matcher = MatchesPredicate(is_even, "%s is not even")
+    matches_matcher = MatchesPredicate(is_even, _u("%s is not even"))
     matches_matches = [2, 4, 6, 8]
     matches_mismatches = [3, 5, 7, 9]
 
     str_examples = [
-        ("MatchesPredicate(%r, %r)" % (is_even, "%s is not even"),
-         MatchesPredicate(is_even, "%s is not even")),
+        ("MatchesPredicate(%r, %r)" % (is_even, _u("%s is not even")),
+         MatchesPredicate(is_even, _u("%s is not even"))),
         ]
 
     describe_examples = [
-        ('7 is not even', 7, MatchesPredicate(is_even, "%s is not even")),
+        ('7 is not even', 7, MatchesPredicate(is_even, _u("%s is not even"))),
         ]
 
 
@@ -236,16 +238,16 @@ class TestMatchesPredicateWithParams(TestCase, TestMatchersInterface):
 
     str_examples = [
         ("MatchesPredicateWithParams(%r, %r)(%s)" % (
-            between, "{0} is not between {1} and {2}", "1, 2"),
+            between, _u("{0} is not between {1} and {2}"), "1, 2"),
          MatchesPredicateWithParams(
-            between, "{0} is not between {1} and {2}")(1, 2)),
+             between, _u("{0} is not between {1} and {2}"))(1, 2)),
         ("Between(1, 2)", MatchesPredicateWithParams(
-            between, "{0} is not between {1} and {2}", "Between")(1, 2)),
+            between, _u("{0} is not between {1} and {2}"), "Between")(1, 2)),
         ]
 
     describe_examples = [
         ('1 is not between 2 and 3', 1, MatchesPredicateWithParams(
-            between, "{0} is not between {1} and {2}")(2, 3)),
+            between, _u("{0} is not between {1} and {2}"))(2, 3)),
         ]
 
 

--- a/testtools/tests/matchers/test_higherorder.py
+++ b/testtools/tests/matchers/test_higherorder.py
@@ -44,10 +44,10 @@ class TestAllMatch(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ('Differences: [\n'
-         '10 is not > 11\n'
-         '10 is not > 10\n'
-         ']',
+        (_u('Differences: [\n'
+            '10 is not > 11\n'
+            '10 is not > 10\n'
+            ']'),
          [11, 9, 10],
          AllMatch(LessThan(10))),
         ]
@@ -75,11 +75,11 @@ class TestAnyMatch(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ('Differences: [\n'
-         '7 != 11\n'
-         '7 != 9\n'
-         '7 != 10\n'
-         ']',
+        (_u('Differences: [\n'
+            '7 != 11\n'
+            '7 != 9\n'
+            '7 != 10\n'
+            ']'),
          [11, 9, 10],
          AnyMatch(Equals(7))),
         ]
@@ -100,9 +100,9 @@ class TestAfterPreprocessing(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ("1 != 0: after <function parity> on 2", 2,
+        (_u("1 != 0: after <function parity> on 2"), 2,
          AfterPreprocessing(parity, Equals(1))),
-        ("1 != 0", 2,
+        (_u("1 != 0"), 2,
          AfterPreprocessing(parity, Equals(1), annotate=False)),
         ]
 
@@ -118,7 +118,7 @@ class TestMatchersAnyInterface(TestCase, TestMatchersInterface):
         MatchesAny(DocTestMatches("1"), DocTestMatches("2"))),
         ]
 
-    describe_examples = [("""Differences: [
+    describe_examples = [(_u("""Differences: [
 Expected:
     1
 Got:
@@ -129,8 +129,7 @@ Expected:
 Got:
     3
 
-]""",
-        "3", MatchesAny(DocTestMatches("1"), DocTestMatches("2")))]
+]"""), "3", MatchesAny(DocTestMatches("1"), DocTestMatches("2")))]
 
 
 class TestMatchesAllInterface(TestCase, TestMatchersInterface):
@@ -144,13 +143,13 @@ class TestMatchesAllInterface(TestCase, TestMatchersInterface):
          MatchesAll(NotEquals(1), NotEquals(2)))]
 
     describe_examples = [
-        ("""Differences: [
+        (_u("""Differences: [
 1 == 1
-]""",
+]"""),
          1, MatchesAll(NotEquals(1), NotEquals(2))),
-        ("1 == 1", 1,
+        (_u("1 == 1"), 1,
          MatchesAll(NotEquals(2), NotEquals(1), Equals(3), first_only=True)),
-        ]
+    ]
 
 
 class TestAnnotate(TestCase, TestMatchersInterface):
@@ -162,7 +161,7 @@ class TestAnnotate(TestCase, TestMatchersInterface):
     str_examples = [
         ("Annotate('foo', Equals(1))", Annotate("foo", Equals(1)))]
 
-    describe_examples = [("1 != 2: foo", 2, Annotate('foo', Equals(1)))]
+    describe_examples = [(_u("1 != 2: foo"), 2, Annotate('foo', Equals(1)))]
 
     def test_if_message_no_message(self):
         # Annotate.if_message returns the given matcher if there is no
@@ -202,7 +201,7 @@ class TestNotInterface(TestCase, TestMatchersInterface):
         ("Not(Equals(1))", Not(Equals(1))),
         ("Not(Equals('1'))", Not(Equals('1')))]
 
-    describe_examples = [('1 matches Equals(1)', 1, Not(Equals(1)))]
+    describe_examples = [(_u('1 matches Equals(1)'), 1, Not(Equals(1)))]
 
 
 def is_even(x):
@@ -246,7 +245,7 @@ class TestMatchesPredicateWithParams(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ('1 is not between 2 and 3', 1, MatchesPredicateWithParams(
+        (_u('1 is not between 2 and 3'), 1, MatchesPredicateWithParams(
             between, _u("{0} is not between {1} and {2}"))(2, 3)),
         ]
 

--- a/testtools/tests/matchers/test_impl.py
+++ b/testtools/tests/matchers/test_impl.py
@@ -1,9 +1,9 @@
-# Copyright (c) 2008-2012 testtools developers. See LICENSE for details.
+# Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
 """Tests for matchers."""
 
 from testtools import (
-    Matcher, # check that Matcher is exposed at the top level for docs.
+    Matcher,  # check that Matcher is exposed at the top level for docs.
     TestCase,
     )
 from testtools.compat import (
@@ -32,13 +32,14 @@ class TestMismatch(TestCase):
     run_tests_with = FullStackRunTest
 
     def test_constructor_arguments(self):
-        mismatch = Mismatch("some description", {'detail': "things"})
-        self.assertEqual("some description", mismatch.describe())
+        mismatch = Mismatch(_u("some description"), {'detail': "things"})
+        self.assertEqual(_u("some description"), mismatch.describe())
         self.assertEqual({'detail': "things"}, mismatch.get_details())
 
     def test_constructor_no_arguments(self):
         mismatch = Mismatch()
-        self.assertThat(mismatch.describe,
+        self.assertThat(
+            mismatch.describe,
             Raises(MatchesException(NotImplementedError)))
         self.assertEqual({}, mismatch.get_details())
 

--- a/testtools/tests/matchers/test_impl.py
+++ b/testtools/tests/matchers/test_impl.py
@@ -22,6 +22,7 @@ from testtools.matchers._impl import (
     MismatchError,
     )
 from testtools.tests.helpers import FullStackRunTest
+from .helpers import _valid_mismatch
 
 # Silence pyflakes.
 Matcher
@@ -42,6 +43,11 @@ class TestMismatch(TestCase):
             mismatch.describe,
             Raises(MatchesException(NotImplementedError)))
         self.assertEqual({}, mismatch.get_details())
+
+    def test_valid_mismatch(self):
+        # Mismatch returns objects that implement IMismatch correctly.
+        mismatch = Mismatch(_u("some description"), {'detail': "things"})
+        self.assertThat(mismatch, _valid_mismatch())
 
 
 class TestMismatchError(TestCase):
@@ -110,18 +116,24 @@ class TestMismatchDecorator(TestCase):
 
     run_tests_with = FullStackRunTest
 
+    def test_valid_mismatch(self):
+        # MismatchDecorator implements IMismatch correctly.
+        x = Mismatch(_u("description"), {'foo': 'bar'})
+        decorated = MismatchDecorator(x)
+        self.assertThat(decorated, _valid_mismatch())
+
     def test_forwards_description(self):
-        x = Mismatch("description", {'foo': 'bar'})
+        x = Mismatch(_u("description"), {'foo': 'bar'})
         decorated = MismatchDecorator(x)
         self.assertEqual(x.describe(), decorated.describe())
 
     def test_forwards_details(self):
-        x = Mismatch("description", {'foo': 'bar'})
+        x = Mismatch(_u("description"), {'foo': 'bar'})
         decorated = MismatchDecorator(x)
         self.assertEqual(x.get_details(), decorated.get_details())
 
     def test_repr(self):
-        x = Mismatch("description", {'foo': 'bar'})
+        x = Mismatch(_u("description"), {'foo': 'bar'})
         decorated = MismatchDecorator(x)
         self.assertEqual(
             '<testtools.matchers.MismatchDecorator(%r)>' % (x,),

--- a/testtools/tests/test_compat.py
+++ b/testtools/tests/test_compat.py
@@ -1,12 +1,9 @@
-# Copyright (c) 2010 testtools developers. See LICENSE for details.
+# Copyright (c) 2010-2015 testtools developers. See LICENSE for details.
 
 """Tests for miscellaneous compatibility functions"""
 
 import io
-import linecache2 as linecache
-import os
 import sys
-import tempfile
 import traceback
 
 import testtools
@@ -16,17 +13,15 @@ from testtools.compat import (
     _u,
     reraise,
     str_is_unicode,
+    text,
     text_repr,
     unicode_output_stream,
-    )
+)
 from testtools.matchers import (
-    Equals,
     Is,
     IsInstance,
-    MatchesException,
     Not,
-    Raises,
-    )
+)
 
 
 class _FakeOutputStream(object):
@@ -37,6 +32,13 @@ class _FakeOutputStream(object):
 
     def write(self, obj):
         self.writelog.append(obj)
+
+
+class TestText(testtools.TestCase):
+    """Tests for ``text``."""
+
+    def test_unicode_literal_is_text(self):
+        self.assertThat(_u('foo'), IsInstance(text))
 
 
 class TestUnicodeOutputStream(testtools.TestCase):
@@ -76,7 +78,7 @@ class TestUnicodeOutputStream(testtools.TestCase):
         unicode_output_stream(sout).write(self.uni)
         self.assertEqual([_b("pa?\xe8?n")], sout.writelog)
 
-    @testtools.skipIf(str_is_unicode, "Tests behaviour when str is not unicode")
+    @testtools.skipIf(str_is_unicode, "Tests behavior when str is not unicode")
     def test_unicode_encodings_wrapped_when_str_is_not_unicode(self):
         """A unicode encoding is wrapped but needs no error handler"""
         sout = _FakeOutputStream()
@@ -86,7 +88,7 @@ class TestUnicodeOutputStream(testtools.TestCase):
         uout.write(self.uni)
         self.assertEqual([_b("pa\xc9\xaa\xce\xb8\xc9\x99n")], sout.writelog)
 
-    @testtools.skipIf(not str_is_unicode, "Tests behaviour when str is unicode")
+    @testtools.skipIf(not str_is_unicode, "Tests behavior when str is unicode")
     def test_unicode_encodings_not_wrapped_when_str_is_unicode(self):
         # No wrapping needed if native str type is unicode
         sout = _FakeOutputStream()
@@ -256,7 +258,6 @@ class TestTextRepr(testtools.TestCase):
             self.assertEqual(eval(actual), u)
 
 
-
 class TestReraise(testtools.TestCase):
     """Tests for trivial reraise wrapper needed for Python 2/3 changes"""
 
@@ -273,7 +274,8 @@ class TestReraise(testtools.TestCase):
         self.assertIs(_exc_info[0], _new_exc_info[0])
         self.assertIs(_exc_info[1], _new_exc_info[1])
         expected_tb = traceback.extract_tb(_exc_info[2])
-        self.assertEqual(expected_tb,
+        self.assertEqual(
+            expected_tb,
             traceback.extract_tb(_new_exc_info[2])[-len(expected_tb):])
 
     def test_custom_exception_no_args(self):


### PR DESCRIPTION
We talked about having explicit interfaces for things. This PR has come out of my various experiments for adding such things. It adds `IMatcher` and `IMismatch` interfaces, makes the documentation and call sites refer to them and updates the interface tests to use them.

It also updates the filesystem matcher tests to actually _use_ the interface tests.

I made the call that `IMismatch.describe` should return text, not bytes, as it seems like the right type, and  doesn't impose an onerous burden for implementers. All of the code that handles bytes is still there, but I've tried put deprecation warnings in wherever someone might pass bytes, or might pass their own matcher that returns a byte-returning mismatcher.

Much of the patch is updating all of the tests and all of the matchers to actually return unicode.

Future work:

* Add interfaces for `Content` so the matcher interface tests can be more thorough
* Add interface for `IDetailed` for objects that support adding and getting details 
* Add optional `detailed` parameter to `assert_that` standalone method so that it implements the full functionality of `TestCase.assertThat`
* Remove `Matcher` and `Mismatch` subclassing from all builtin matchers and mismatches

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/181)
<!-- Reviewable:end -->
