### PR TITLE
Swap Equals order

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,7 +21,11 @@ Changes
 -------
 
 * Add a new test dependency of testscenarios. (Robert Collins)
-  
+
+* Getting ``expected`` or ``observed`` attributes from binary comparison
+  mismatches (e.g. ``Equals(2).match(3).expected``) is now deprecated.
+  (Jonathan Lange)
+
 1.8.1
 ~~~~~
 

--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,11 @@ Improvements
 * ``MatchesListwise`` has more informative error when lengths don't match.
   (Jonathan Lange)
 
+* The short form of errors for failed binary comparisions will now put the
+  expected value on the _right_. This means that ``assertThat(2, Equals(3))``
+  will raise an error saying ``2 != 3``.
+  (Jonathan Lange, #1525227)
+
 Changes
 -------
 

--- a/testtools/matchers/_basic.py
+++ b/testtools/matchers/_basic.py
@@ -57,7 +57,7 @@ class _BinaryComparison(object):
     def match(self, other):
         if self.comparator(other, self.expected):
             return None
-        return _BinaryMismatch(self.expected, self.mismatch_string, other)
+        return _BinaryMismatch(other, self.mismatch_string, self.expected)
 
     def comparator(self, expected, other):
         raise NotImplementedError(self.comparator)
@@ -111,14 +111,14 @@ class LessThan(_BinaryComparison):
     """Matches if the item is less than the matchers reference object."""
 
     comparator = operator.__lt__
-    mismatch_string = 'is not >'
+    mismatch_string = '>='
 
 
 class GreaterThan(_BinaryComparison):
     """Matches if the item is greater than the matchers reference object."""
 
     comparator = operator.__gt__
-    mismatch_string = 'is not <'
+    mismatch_string = '<='
 
 
 class SameMembers(Matcher):

--- a/testtools/matchers/_basic.py
+++ b/testtools/matchers/_basic.py
@@ -17,6 +17,7 @@ __all__ = [
 import operator
 from pprint import pformat
 import re
+import warnings
 
 from ..compat import (
     _isbytes,
@@ -75,12 +76,20 @@ class _BinaryMismatch(Mismatch):
 
     @property
     def expected(self):
-        # XXX: Deprecated.
+        warnings.warn(
+            '%s.expected deprecated after 1.8.1' % (self.__class__.__name__,),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._reference
 
     @property
     def other(self):
-        # XXX: Deprecated.
+        warnings.warn(
+            '%s.other deprecated after 1.8.1' % (self.__class__.__name__,),
+            DeprecationWarning,
+            stacklevel=2,
+        )
         return self._actual
 
     def describe(self):

--- a/testtools/matchers/_datastructures.py
+++ b/testtools/matchers/_datastructures.py
@@ -39,12 +39,12 @@ class MatchesListwise(object):
     >>> MatchesListwise([Equals(1), Equals(2)]).match([1, 2])
     >>> print (MatchesListwise([Equals(1), Equals(2)]).match([2, 1]).describe())
     Differences: [
-    1 != 2
     2 != 1
+    1 != 2
     ]
     >>> matcher = MatchesListwise([Equals(1), Equals(2)], first_only=True)
     >>> print (matcher.match([3, 4]).describe())
-    1 != 3
+    3 != 1
     """
 
     def __init__(self, matchers, first_only=False):

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -346,8 +346,8 @@ class TestCase(unittest.TestCase):
         :param observed: The observed value.
         :param message: An optional message to include in the error.
         """
-        matcher = Equals(expected)
-        self.assertThat(observed, matcher, message)
+        matcher = Equals(observed)
+        self.assertThat(expected, matcher, message)
 
     failUnlessEqual = assertEquals = assertEqual
 

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -48,6 +48,7 @@ from testtools.matchers import (
     Not,
     Raises,
     )
+from testtools.matchers._basic import _FlippedEquals
 from testtools.monkey import patch
 from testtools.runtest import RunTest
 from testtools.testresult import (
@@ -346,8 +347,8 @@ class TestCase(unittest.TestCase):
         :param observed: The observed value.
         :param message: An optional message to include in the error.
         """
-        matcher = Equals(observed)
-        self.assertThat(expected, matcher, message)
+        matcher = _FlippedEquals(expected)
+        self.assertThat(observed, matcher, message)
 
     failUnlessEqual = assertEquals = assertEqual
 

--- a/testtools/tests/matchers/test_basic.py
+++ b/testtools/tests/matchers/test_basic.py
@@ -55,41 +55,61 @@ class Test_BinaryMismatch(TestCase):
     def test_long_bytes(self):
         one_line_b = self._long_b.replace(_b("\n"), _b(" "))
         mismatch = _BinaryMismatch(one_line_b, "!~", self._long_b)
-        self.assertEqual(mismatch.describe(),
-            "%s:\nreference = %s\nactual    = %s\n" % ("!~",
+        self.assertEqual(
+            mismatch.describe(),
+            "%s:\nreference = %s\nactual    = %s\n" % (
+                "!~",
+                text_repr(self._long_b, multiline=True),
                 text_repr(one_line_b),
-                text_repr(self._long_b, multiline=True)))
+            )
+        )
 
     def test_long_unicode(self):
         one_line_u = self._long_u.replace("\n", " ")
         mismatch = _BinaryMismatch(one_line_u, "!~", self._long_u)
-        self.assertEqual(mismatch.describe(),
-            "%s:\nreference = %s\nactual    = %s\n" % ("!~",
+        self.assertEqual(
+            mismatch.describe(),
+            "%s:\nreference = %s\nactual    = %s\n" % (
+                "!~",
+                text_repr(self._long_u, multiline=True),
                 text_repr(one_line_u),
-                text_repr(self._long_u, multiline=True)))
+            )
+        )
 
     def test_long_mixed_strings(self):
         mismatch = _BinaryMismatch(self._long_b, "!~", self._long_u)
-        self.assertEqual(mismatch.describe(),
-            "%s:\nreference = %s\nactual    = %s\n" % ("!~",
+        self.assertEqual(
+            mismatch.describe(),
+            "%s:\nreference = %s\nactual    = %s\n" % (
+                "!~",
+                text_repr(self._long_u, multiline=True),
                 text_repr(self._long_b, multiline=True),
-                text_repr(self._long_u, multiline=True)))
+            )
+        )
 
     def test_long_bytes_and_object(self):
         obj = object()
         mismatch = _BinaryMismatch(self._long_b, "!~", obj)
-        self.assertEqual(mismatch.describe(),
-            "%s:\nreference = %s\nactual    = %s\n" % ("!~",
+        self.assertEqual(
+            mismatch.describe(),
+            "%s:\nreference = %s\nactual    = %s\n" % (
+                "!~",
+                repr(obj),
                 text_repr(self._long_b, multiline=True),
-                repr(obj)))
+            )
+        )
 
     def test_long_unicode_and_object(self):
         obj = object()
         mismatch = _BinaryMismatch(self._long_u, "!~", obj)
-        self.assertEqual(mismatch.describe(),
-            "%s:\nreference = %s\nactual    = %s\n" % ("!~",
+        self.assertEqual(
+            mismatch.describe(),
+            "%s:\nreference = %s\nactual    = %s\n" % (
+                "!~",
+                repr(obj),
                 text_repr(self._long_u, multiline=True),
-                repr(obj)))
+            )
+        )
 
 
 class TestEqualsInterface(TestCase, TestMatchersInterface):
@@ -100,7 +120,14 @@ class TestEqualsInterface(TestCase, TestMatchersInterface):
 
     str_examples = [("Equals(1)", Equals(1)), ("Equals('1')", Equals('1'))]
 
-    describe_examples = [("2 != 1", 2, Equals(1))]
+    describe_examples = [
+        ("2 != 1", 2, Equals(1)),
+        (("!=:\n"
+          "reference = 'abcdefghijklmnopqrstuvwxyz0123456789'\n"
+          "actual    = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'\n"),
+         'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+         Equals('abcdefghijklmnopqrstuvwxyz0123456789')),
+    ]
 
 
 class TestNotEqualsInterface(TestCase, TestMatchersInterface):

--- a/testtools/tests/matchers/test_basic.py
+++ b/testtools/tests/matchers/test_basic.py
@@ -100,7 +100,7 @@ class TestEqualsInterface(TestCase, TestMatchersInterface):
 
     str_examples = [("Equals(1)", Equals(1)), ("Equals('1')", Equals('1'))]
 
-    describe_examples = [("1 != 2", 2, Equals(1))]
+    describe_examples = [("2 != 1", 2, Equals(1))]
 
 
 class TestNotEqualsInterface(TestCase, TestMatchersInterface):
@@ -126,7 +126,7 @@ class TestIsInterface(TestCase, TestMatchersInterface):
 
     str_examples = [("Is(2)", Is(2))]
 
-    describe_examples = [("1 is not 2", 2, Is(1))]
+    describe_examples = [("2 is not 1", 2, Is(1))]
 
 
 class TestIsInstanceInterface(TestCase, TestMatchersInterface):
@@ -160,8 +160,8 @@ class TestLessThanInterface(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ('4 is not > 5', 5, LessThan(4)),
-        ('4 is not > 4', 4, LessThan(4)),
+        ('5 >= 4', 5, LessThan(4)),
+        ('4 >= 4', 4, LessThan(4)),
         ]
 
 
@@ -176,8 +176,8 @@ class TestGreaterThanInterface(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ('5 is not < 4', 4, GreaterThan(5)),
-        ('4 is not < 4', 4, GreaterThan(4)),
+        ('4 <= 5', 4, GreaterThan(5)),
+        ('4 <= 4', 4, GreaterThan(4)),
         ]
 
 

--- a/testtools/tests/matchers/test_datastructures.py
+++ b/testtools/tests/matchers/test_datastructures.py
@@ -37,6 +37,8 @@ class TestMatchesListwise(TestCase):
 
     run_tests_with = FullStackRunTest
 
+    # XXX: Add interface tests.
+
     def test_docstring(self):
         failure_count, output = run_doctest(
             MatchesListwise, "MatchesListwise")
@@ -69,16 +71,16 @@ class TestMatchesStructure(TestCase, TestMatchersInterface):
     describe_examples = [
         ("""\
 Differences: [
-3 != 1: x
+1 != 3: x
 ]""", SimpleClass(1, 2), MatchesStructure(x=Equals(3), y=Equals(2))),
         ("""\
 Differences: [
-3 != 2: y
+2 != 3: y
 ]""", SimpleClass(1, 2), MatchesStructure(x=Equals(1), y=Equals(3))),
         ("""\
 Differences: [
-0 != 1: x
-0 != 2: y
+1 != 0: x
+2 != 0: y
 ]""", SimpleClass(1, 2), MatchesStructure(x=Equals(0), y=Equals(0))),
         ]
 

--- a/testtools/tests/matchers/test_dict.py
+++ b/testtools/tests/matchers/test_dict.py
@@ -102,7 +102,7 @@ class TestMatchesDict(TestCase, TestMatchersInterface):
 
     str_examples = [
         ("MatchesDict({'baz': %s, 'foo': %s})" % (
-                Not(Equals('qux')), Equals('bar')),
+            Not(Equals('qux')), Equals('bar')),
          matches_matcher),
         ]
 
@@ -118,7 +118,7 @@ class TestMatchesDict(TestCase, TestMatchersInterface):
          {'foo': 'bar', 'baz': 'qux'}, matches_matcher),
         ("Differences: {\n"
          "  'baz': 'qux' matches Equals('qux'),\n"
-         "  'foo': 'bar' != 'bop',\n"
+         "  'foo': 'bop' != 'bar',\n"
          "}",
          {'foo': 'bop', 'baz': 'qux'}, matches_matcher),
         ("Extra: {\n"
@@ -155,7 +155,7 @@ class TestContainsDict(TestCase, TestMatchersInterface):
 
     str_examples = [
         ("ContainsDict({'baz': %s, 'foo': %s})" % (
-                Not(Equals('qux')), Equals('bar')),
+            Not(Equals('qux')), Equals('bar')),
          matches_matcher),
         ]
 
@@ -171,7 +171,7 @@ class TestContainsDict(TestCase, TestMatchersInterface):
          {'foo': 'bar', 'baz': 'qux'}, matches_matcher),
         ("Differences: {\n"
          "  'baz': 'qux' matches Equals('qux'),\n"
-         "  'foo': 'bar' != 'bop',\n"
+         "  'foo': 'bop' != 'bar',\n"
          "}",
          {'foo': 'bop', 'baz': 'qux'}, matches_matcher),
         ("Missing: {\n"
@@ -201,7 +201,7 @@ class TestContainedByDict(TestCase, TestMatchersInterface):
 
     str_examples = [
         ("ContainedByDict({'baz': %s, 'foo': %s})" % (
-                Not(Equals('qux')), Equals('bar')),
+            Not(Equals('qux')), Equals('bar')),
          matches_matcher),
         ]
 
@@ -212,7 +212,7 @@ class TestContainedByDict(TestCase, TestMatchersInterface):
          {'foo': 'bar', 'baz': 'qux'}, matches_matcher),
         ("Differences: {\n"
          "  'baz': 'qux' matches Equals('qux'),\n"
-         "  'foo': 'bar' != 'bop',\n"
+         "  'foo': 'bop' != 'bar',\n"
          "}",
          {'foo': 'bop', 'baz': 'qux'}, matches_matcher),
         ("Extra: {\n"

--- a/testtools/tests/matchers/test_exception.py
+++ b/testtools/tests/matchers/test_exception.py
@@ -100,7 +100,7 @@ class TestMatchesExceptionTypeMatcherInterface(TestCase, TestMatchersInterface):
          MatchesException(Exception, Equals('foo')))
         ]
     describe_examples = [
-        ("5 != %r" % (error_bar[1],),
+        ("%r != 5" % (error_bar[1],),
          error_bar, MatchesException(ValueError, Equals(5))),
         ]
 

--- a/testtools/tests/matchers/test_higherorder.py
+++ b/testtools/tests/matchers/test_higherorder.py
@@ -44,8 +44,8 @@ class TestAllMatch(TestCase, TestMatchersInterface):
 
     describe_examples = [
         ('Differences: [\n'
-         '10 is not > 11\n'
-         '10 is not > 10\n'
+         '11 >= 10\n'
+         '10 >= 10\n'
          ']',
          [11, 9, 10],
          AllMatch(LessThan(10))),
@@ -75,9 +75,9 @@ class TestAnyMatch(TestCase, TestMatchersInterface):
 
     describe_examples = [
         ('Differences: [\n'
-         '7 != 11\n'
-         '7 != 9\n'
-         '7 != 10\n'
+         '11 != 7\n'
+         '9 != 7\n'
+         '10 != 7\n'
          ']',
          [11, 9, 10],
          AnyMatch(Equals(7))),
@@ -99,11 +99,12 @@ class TestAfterPreprocessing(TestCase, TestMatchersInterface):
         ]
 
     describe_examples = [
-        ("1 != 0: after <function parity> on 2", 2,
+        ("0 != 1: after <function parity> on 2", 2,
          AfterPreprocessing(parity, Equals(1))),
-        ("1 != 0", 2,
+        ("0 != 1", 2,
          AfterPreprocessing(parity, Equals(1), annotate=False)),
         ]
+
 
 class TestMatchersAnyInterface(TestCase, TestMatchersInterface):
 
@@ -160,7 +161,7 @@ class TestAnnotate(TestCase, TestMatchersInterface):
     str_examples = [
         ("Annotate('foo', Equals(1))", Annotate("foo", Equals(1)))]
 
-    describe_examples = [("1 != 2: foo", 2, Annotate('foo', Equals(1)))]
+    describe_examples = [("2 != 1: foo", 2, Annotate('foo', Equals(1)))]
 
     def test_if_message_no_message(self):
         # Annotate.if_message returns the given matcher if there is no

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -495,14 +495,14 @@ class TestAssertions(TestCase):
     def test_assertIs_fails(self):
         # assertIs raises assertion errors if one object is not identical to
         # another.
-        self.assertFails('None is not 42', self.assertIs, None, 42)
+        self.assertFails('42 is not None', self.assertIs, None, 42)
         self.assertFails('[42] is not [42]', self.assertIs, [42], [42])
 
     def test_assertIs_fails_with_message(self):
         # assertIs raises assertion errors if one object is not identical to
         # another, and includes a user-supplied message, if it's provided.
         self.assertFails(
-            'None is not 42: foo bar', self.assertIs, None, 42, 'foo bar')
+            '42 is not None: foo bar', self.assertIs, None, 42, 'foo bar')
 
     def test_assertIsNot(self):
         # assertIsNot asserts that an object is not identical to another
@@ -712,7 +712,7 @@ class TestAssertions(TestCase):
     def test_assertIsNone(self):
         self.assertIsNone(None)
 
-        expected_error = 'None is not 0'
+        expected_error = '0 is not None'
         self.assertFails(expected_error, self.assertIsNone, 0)
 
     def test_assertIsNotNone(self):


### PR DESCRIPTION
From https://bugs.launchpad.net/testtools/+bug/1525227:

A test that does this:

```python
self.assertThat('a', Equals('b'))
```

Will report an error that looks like this:

    testtools.matchers._impl.MismatchError: 'b' != 'a'

I would expect it to look like this instead:

    testtools.matchers._impl.MismatchError: 'a' != 'b'

So that the order of arguments in the assertion matches the order of values in the error.

This patch makes that change. Some tomfoolery was needed to have the same principle hold for `assertEqual` which documents `expected` as its first parameter.

Also deprecates `_BinaryMismatch.expected` and `_BinaryMismatch.observed` attributes, which really don't need to be public at all.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/182)
<!-- Reviewable:end -->
