### PR TITLE
Deprecate TestCase.skip

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -16,7 +16,10 @@ Changes
 -------
 
 * Add a new test dependency of testscenarios. (Robert Collins)
-  
+
+* ``TestCase.skip`` deprecated. Use ``skipTest`` instead.
+  (Jonathan Lange, #988893)
+
 1.8.1
 ~~~~~
 

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -20,6 +20,7 @@ import functools
 import itertools
 import sys
 import types
+import warnings
 
 from extras import (
     safe_hasattr,
@@ -291,9 +292,12 @@ class TestCase(unittest.TestCase):
         """
         raise self.skipException(reason)
 
-    # skipTest is how python2.7 spells this. Sometime in the future
-    # This should be given a deprecation decorator - RBC 20100611.
-    skip = skipTest
+    def skip(self, reason):
+        """DEPRECATED: Use skipTest instead."""
+        warnings.warn(
+            'Only valid in 1.8.1 and earlier. Use skipTest instead.',
+            DeprecationWarning, stacklevel=2)
+        self.skipTest(reason)
 
     def _formatTypes(self, classOrIterable):
         """Format a class or a bunch of classes for display in an error."""


### PR DESCRIPTION
There's been a comment saying that we should deprecate it for some time. This patch does so.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/183)
<!-- Reviewable:end -->
