### PR TITLE
Document early evaluation of details

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -161,6 +161,9 @@ def _copy_content(content_object):
 def gather_details(source_dict, target_dict):
     """Merge the details from ``source_dict`` into ``target_dict``.
 
+    ``gather_details`` evaluates all details in ``source_dict``. Do not use it
+    if the details are not ready to be evaluated.
+
     :param source_dict: A dictionary of details will be gathered.
     :param target_dict: A dictionary into which details will be gathered.
     """


### PR DESCRIPTION
https://bugs.launchpad.net/testtools/+bug/801031 complains that `gather_details` evaluates details. However, this is the supported behaviour—python-fixtures relies on it.

There's definitely good future work we can do here, e.g.:

* bring `combine_details` over
* make a non-mutatey function that combines details dicts and returns them without mutating the original dicts
* make a function that simply evaluates the details in a details dict
* move details-related stuff to a separate module, `_details`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/184)
<!-- Reviewable:end -->
