### PR TITLE
Tests for assertRaisesRegexp

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -19,6 +19,8 @@ Improvements
   will raise an error saying ``2 != 3``.
   (Jonathan Lange, #1525227)
 
+* Tests for ``assertRaisesRegexp``. (Julia Varlamova, Jonathan Lange)
+
 Changes
 -------
 

--- a/README.rst
+++ b/README.rst
@@ -93,3 +93,5 @@ Thanks
  * Christian Kampka
  * Gavin Panella
  * Martin Pool
+ * Julia Varlamova
+ * ClusterHQ Ltd

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -42,6 +42,7 @@ from testtools.matchers import (
     Equals,
     MatchesAll,
     MatchesException,
+    MatchesRegex,
     MismatchError,
     Is,
     IsInstance,
@@ -422,6 +423,16 @@ class TestCase(unittest.TestCase):
         self.assertThat(our_callable, matcher)
         return capture.matchee
     failUnlessRaises = assertRaises
+
+    def assertRaisesRegexp(self, excClass, pattern, callableObj, *args,
+                           **kwargs):
+        """Fail unless an exception of class excClass is thrown
+           by callableObj when invoked with arguments args and keyword
+           arguments kwargs and exception message matches pattern.
+        """
+        exception = self.assertRaises(excClass, callableObj, *args, **kwargs)
+        matcher = MatchesRegex(pattern)
+        self.assertThat(exception.args[0], matcher)
 
     def assertThat(self, matchee, matcher, message='', verbose=False):
         """Assert that matchee is matched by matcher.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -42,7 +42,6 @@ from testtools.matchers import (
     Equals,
     MatchesAll,
     MatchesException,
-    MatchesRegex,
     MismatchError,
     Is,
     IsInstance,
@@ -423,16 +422,6 @@ class TestCase(unittest.TestCase):
         self.assertThat(our_callable, matcher)
         return capture.matchee
     failUnlessRaises = assertRaises
-
-    def assertRaisesRegexp(self, excClass, pattern, callableObj, *args,
-                           **kwargs):
-        """Fail unless an exception of class excClass is thrown
-           by callableObj when invoked with arguments args and keyword
-           arguments kwargs and exception message matches pattern.
-        """
-        exception = self.assertRaises(excClass, callableObj, *args, **kwargs)
-        matcher = MatchesRegex(pattern)
-        self.assertThat(exception.args[0], matcher)
 
     def assertThat(self, matchee, matcher, message='', verbose=False):
         """Assert that matchee is matched by matcher.

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -383,15 +383,17 @@ class TestAssertions(TestCase):
 
     def test_assertRaisesRegexp_wrong_error_type(self):
         # If function raises an exception of unexpected type,
-        # assertRaisesRegexp re-raise it.
-        self.assertRaises(SyntaxError, self.assertRaisesRegexp, RuntimeError,
-                          "M\w*e", self.raiseError, SyntaxError, "Message")
+        # assertRaisesRegexp re-raises it.
+        self.assertRaises(ValueError, self.assertRaisesRegexp, RuntimeError,
+                          "M\w*e", self.raiseError, ValueError, "Message")
 
     def test_assertRaisesRegexp_wrong_message(self):
         # If function raises an exception with unexpected message
-        # assertRaisesregexp raise MismatchError.
-        self.assertRaises(MismatchError, self.assertRaisesRegexp, RuntimeError,
-                          "Msg", self.raiseError, RuntimeError, "Message")
+        # assertRaisesRegexp fails.
+        self.assertFails(
+            '"Expected" does not match "Observed"',
+            self.assertRaisesRegexp, RuntimeError, "Expected",
+            self.raiseError, RuntimeError, "Observed")
 
     def assertFails(self, message, function, *args, **kwargs):
         """Assert that function raises a failure with the given message."""

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -34,6 +34,7 @@ from testtools.matchers import (
     Equals,
     HasLength,
     MatchesException,
+    MismatchError,
     Raises,
     )
 from testtools.testcase import (
@@ -373,6 +374,24 @@ class TestAssertions(TestCase):
             lambda: self.assertRaises(Exception, foo),
             Raises(
                 MatchesException(self.failureException, '.*%r.*' % (foo,))))
+
+    def test_assertRaisesRegexp(self):
+        # assertRaisesRegexp asserts that function raises particular exception
+        # with particular message.
+        self.assertRaisesRegexp(RuntimeError, "M\w*e", self.raiseError,
+                                RuntimeError, "Message")
+
+    def test_assertRaisesRegexp_wrong_error_type(self):
+        # If function raises an exception of unexpected type,
+        # assertRaisesRegexp re-raise it.
+        self.assertRaises(SyntaxError, self.assertRaisesRegexp, RuntimeError,
+                          "M\w*e", self.raiseError, SyntaxError, "Message")
+
+    def test_assertRaisesRegexp_wrong_message(self):
+        # If function raises an exception with unexpected message
+        # assertRaisesregexp raise MismatchError.
+        self.assertRaises(MismatchError, self.assertRaisesRegexp, RuntimeError,
+                          "Msg", self.raiseError, RuntimeError, "Message")
 
     def assertFails(self, message, function, *args, **kwargs):
         """Assert that function raises a failure with the given message."""

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -34,7 +34,6 @@ from testtools.matchers import (
     Equals,
     HasLength,
     MatchesException,
-    MismatchError,
     Raises,
     )
 from testtools.testcase import (


### PR DESCRIPTION
Builds on #75 by taking the tests, adjusting them to use the helpers we already have, and then deleting `assertRaisesRegexp`, relying instead on the one we get from unittest.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/185)
<!-- Reviewable:end -->
