### PR TITLE
Suppress traceback based on skipException

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -21,6 +21,9 @@ Improvements
 
 * Tests for ``assertRaisesRegexp``. (Julia Varlamova, Jonathan Lange)
 
+* Tests that customize ``skipException`` no longer get tracebacks for skipped
+  tests.  (Jonathan Lange)
+
 Changes
 -------
 

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -560,7 +560,7 @@ class TestCase(unittest.TestCase):
         :seealso addOnException:
         """
         if exc_info[0] not in [
-            TestSkipped, _UnexpectedSuccess, _ExpectedFailure]:
+                TestSkipped, _UnexpectedSuccess, _ExpectedFailure]:
             self._report_traceback(exc_info, tb_label=tb_label)
         for handler in self.__exception_handlers:
             handler(exc_info)

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -560,7 +560,7 @@ class TestCase(unittest.TestCase):
         :seealso addOnException:
         """
         if exc_info[0] not in [
-                TestSkipped, _UnexpectedSuccess, _ExpectedFailure]:
+                self.skipException, _UnexpectedSuccess, _ExpectedFailure]:
             self._report_traceback(exc_info, tb_label=tb_label)
         for handler in self.__exception_handlers:
             handler(exc_info)

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1145,9 +1145,20 @@ class TestDetailsProvided(TestWithDetails):
         class Case(TestCase):
             def test(this):
                 this.addDetail("foo", self.get_content())
-                self.skip('yo')
+                self.skipTest('yo')
         self.assertDetailsProvided(Case("test"), "addSkip",
             ["foo", "reason"])
+
+    def test_addSkip_different_exception(self):
+        # No traceback is included if the skip exception is changed and a skip
+        # is raised.
+        class Case(TestCase):
+            skipException = ValueError
+
+            def test(this):
+                this.addDetail("foo", self.get_content())
+                this.skipTest('yo')
+        self.assertDetailsProvided(Case("test"), "addSkip", ["foo", "reason"])
 
     def test_addSucccess(self):
         class Case(TestCase):


### PR DESCRIPTION
Hard-coding `TestSkipped` is a bit weird since we allow customization.

Also updates a nearby test to use `skipTest` rather than the deprecated `skip`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/189)
<!-- Reviewable:end -->
