### PR TITLE
Prefer standard library SkipTest to unittest2.SkipTest

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -43,6 +43,10 @@ Changes
 * Report on all duplicate test ids when sorting test suites that contain
   duplicate ids.  (Thomas Bechtold, Jonathan Lange)
 
+* On Pythons greater than 2.6, ``TestSkipped`` will default to
+  ``unittest.SkipTest``, even if ``unittest2`` is installed.
+  (Jonathan Lange, #1529143)
+
 1.8.1
 ~~~~~
 

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2011 testtools developers. See LICENSE for details.
+# Copyright (c) 2008-2015 testtools developers. See LICENSE for details.
 
 """Test case related stuff."""
 
@@ -19,7 +19,6 @@ import copy
 import functools
 import itertools
 import sys
-import types
 import warnings
 
 from extras import (
@@ -40,7 +39,6 @@ from testtools.compat import (
 from testtools.matchers import (
     Annotate,
     Contains,
-    Equals,
     MatchesAll,
     MatchesException,
     MismatchError,
@@ -59,8 +57,11 @@ from testtools.testresult import (
 
 wraps = try_import('functools.wraps')
 
+
 class TestSkipped(Exception):
     """Raised within TestCase.run() when a test is skipped."""
+
+
 TestSkipped = try_import('unittest.case.SkipTest', TestSkipped)
 TestSkipped = try_import('unittest2.case.SkipTest', TestSkipped)
 
@@ -75,6 +76,7 @@ _UnexpectedSuccess = try_import(
     'unittest.case._UnexpectedSuccess', _UnexpectedSuccess)
 _UnexpectedSuccess = try_import(
     'unittest2.case._UnexpectedSuccess', _UnexpectedSuccess)
+
 
 class _ExpectedFailure(Exception):
     """An expected failure occured.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -62,8 +62,11 @@ class TestSkipped(Exception):
     """Raised within TestCase.run() when a test is skipped."""
 
 
-TestSkipped = try_import('unittest.case.SkipTest', TestSkipped)
+# The order here matters. We want to default to the standard library if it's
+# available. After we drop Python 2.6 support, we should drop the 'unittest2'
+# attempt here and deprecate TestSkipped.
 TestSkipped = try_import('unittest2.case.SkipTest', TestSkipped)
+TestSkipped = try_import('unittest.case.SkipTest', TestSkipped)
 
 
 class _UnexpectedSuccess(Exception):


### PR DESCRIPTION
* `TestSkipped` ought to be deprecated, but we should wait until after we stop supporting Python 2.6, since people on Python 2.6 ought to have a version of testtools that isn't spamming them with warnings that we can't fix
* `unittest.SkipTest` is preferred to `unittest2.SkipTest`, so that by default we're using what other libraries are using

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/190)
<!-- Reviewable:end -->
