### PR TITLE
Add requirements for readthedocs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -43,6 +43,9 @@ Changes
 * Report on all duplicate test ids when sorting test suites that contain
   duplicate ids.  (Thomas Bechtold, Jonathan Lange)
 
+* Add ``readthedocs-requirements.txt`` so readthedocs.org can build the
+  Twisted API documentation. (Jonathan Lange)
+
 1.8.1
 ~~~~~
 

--- a/readthedocs-requirements.txt
+++ b/readthedocs-requirements.txt
@@ -1,0 +1,1 @@
+Twisted


### PR DESCRIPTION
Currently, readthedocs is not including the API documentation for Twisted, since we don't declare Twisted as a hard dependency.

This fixes the issue by adding a requirements file specifically devoted to readthedocs. Separately, I've told readthedocs to use this requirements file.

Going to merge this right away, since that seems to be the only way to test it. :(

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/191)
<!-- Reviewable:end -->
