### PR TITLE
Add requirements for readthedocs

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -43,6 +43,9 @@ Changes
 * Report on all duplicate test ids when sorting test suites that contain
   duplicate ids.  (Thomas Bechtold, Jonathan Lange)
 
+* Add ``readthedocs-requirements.txt`` so readthedocs.org can build the
+  Twisted API documentation. (Jonathan Lange)
+
 1.8.1
 ~~~~~
 

--- a/readthedocs-requirements.txt
+++ b/readthedocs-requirements.txt
@@ -1,0 +1,1 @@
+Twisted

--- a/readthedocs-requirements.txt
+++ b/readthedocs-requirements.txt
@@ -1,1 +1,2 @@
+-e .[test]
 Twisted

--- a/readthedocs-requirements.txt
+++ b/readthedocs-requirements.txt
@@ -1,2 +1,10 @@
--e .[test]
+# Since Twisted is an optional dependency, it doesn't get installed by `python
+# setup.py install`. However, if Twisted is not installed, then the
+# documentation for our Twisted support code won't render on readthedocs.
+#
+# Thus, this requirements.txt is specifically devoted to readthedocs.org, so
+# that it knows exactly what to install in order to render the full
+# documentation.
+
+testtools[test]
 Twisted


### PR DESCRIPTION
Currently, readthedocs is not including the API documentation for Twisted, since we don't declare Twisted as a hard dependency.

This fixes the issue by adding a requirements file specifically devoted to readthedocs. Separately, I've told readthedocs to use this requirements file.

Before: http://testtools.readthedocs.org/en/latest/api.html#testtools-deferredruntest
After: http://testtools.readthedocs.org/en/readthedocs-twisted/api.html#module-testtools.deferredruntest

Now that I've verified that it works, I've reverted the readthedocs config (so that our regular docs will still build). Once I land this PR, I'll restore it (i.e. Set the requirements file to `readthedocs-requirements.txt` on https://readthedocs.org/dashboard/testtools/advanced/).

(Originally #191).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/192)
<!-- Reviewable:end -->
