### PR TITLE
expectThat works under AsynchronousDeferredRunTest

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -24,6 +24,10 @@ Improvements
 * Tests that customize ``skipException`` no longer get tracebacks for skipped
   tests.  (Jonathan Lange)
 
+* A failing ``expectThat`` now fails tests run with
+  ``AsynchronousDeferredRunTest``.  (Jonathan Lange, #1532452)
+
+
 Changes
 -------
 

--- a/testtools/deferredruntest.py
+++ b/testtools/deferredruntest.py
@@ -31,8 +31,8 @@ import sys
 from testtools.compat import StringIO
 from testtools.content import text_content
 from testtools.runtest import RunTest, _raise_force_fail_error
-from testtools._deferred import extract_result
 from testtools._spinner import (
+    extract_result,
     NoResultError,
     Spinner,
     TimeoutError,

--- a/testtools/tests/test_deferredruntest.py
+++ b/testtools/tests/test_deferredruntest.py
@@ -85,6 +85,9 @@ class AsText(AfterPreprocessing):
 class X(object):
     """Tests that we run as part of our tests, nested to avoid discovery."""
 
+    # XXX: After testing-cabal/testtools#165 lands, fix up all of these to be
+    # scenario tests for RunTest.
+
     class Base(TestCase):
         def setUp(self):
             super(X.Base, self).setUp()
@@ -134,6 +137,14 @@ class X(object):
             self.calls.append('test')
             self.addCleanup(lambda: 1/0)
 
+    class ExpectThatFailure(Base):
+        """Calling expectThat with a failing match fails the test."""
+        expected_calls = ['setUp', 'test', 'tearDown', 'clean-up']
+        expected_results = [('addFailure', AssertionError)]
+        def test_something(self):
+            self.calls.append('test')
+            self.expectThat(object(), Is(object()))
+
     class TestIntegration(NeedsTwistedTestCase):
 
         def assertResultsMatch(self, test, result):
@@ -176,7 +187,8 @@ def make_integration_tests():
         X.ErrorInTearDown,
         X.FailureInTest,
         X.ErrorInCleanup,
-        ]
+        X.ExpectThatFailure,
+    ]
     base_test = X.TestIntegration('test_runner')
     integration_tests = []
     for runner_name, runner in runners:


### PR DESCRIPTION
`AsynchronousDeferredRunTest` has an unfortunate bug: if `expectThat` is called and fails, the test passes. See https://bugs.launchpad.net/testtools/+bug/1532452.

This is a critical bug.

There's a deeper bug in our testing strategy for `RunTest`. However, that will be vastly easier to address after #165 lands (and maybe after #181, which will provide us with an interface library), so I'm not tackling it here.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/194)
<!-- Reviewable:end -->
