### PR TITLE
Handle edge case in reactor running

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -38,6 +38,11 @@ Improvements
   between runs. In particular, testtools tests can now be run with
   ``trial -u``.  (Jonathan Lange, #1517879)
 
+* Fixed bug where if an asynchronous ``Deferred`` test times out but the
+  ``Deferred`` then fires, the entire test run would abort with
+  ``KeyboardInterrupt``, failing the currently running test.
+  (Jonathan Lange, James Westby)
+
 
 Changes
 -------

--- a/testtools/_spinner.py
+++ b/testtools/_spinner.py
@@ -153,6 +153,7 @@ class Spinner(object):
         self._saved_signals = []
         self._junk = []
         self._debug = debug
+        self._spinning = False
 
     def _cancel_timeout(self):
         if self._timeout_call:
@@ -186,7 +187,10 @@ class Spinner(object):
 
     def _stop_reactor(self, ignored=None):
         """Stop the reactor!"""
-        self._reactor.crash()
+        # XXX: Would like to emit a warning when called when *not* spinning.
+        if self._spinning:
+            self._reactor.crash()
+            self._spinning = False
 
     def _timed_out(self, function, timeout):
         e = TimeoutError(function, timeout)
@@ -287,6 +291,7 @@ class Spinner(object):
                 d.addBoth(self._stop_reactor)
             try:
                 self._reactor.callWhenRunning(run_function)
+                self._spinning = True
                 self._reactor.run()
             finally:
                 self._reactor.stop = real_stop

--- a/testtools/_spinner.py
+++ b/testtools/_spinner.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010 testtools developers. See LICENSE for details.
+# Copyright (c) testtools developers. See LICENSE for details.
 
 """Evil reactor-spinning logic for running Twisted tests.
 

--- a/testtools/tests/test_spinner.py
+++ b/testtools/tests/test_spinner.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2010 testtools developers. See LICENSE for details.
+# Copyright (c) testtools developers. See LICENSE for details.
 
 """Tests for the evil Twisted reactor-spinning we do."""
 
@@ -118,7 +118,7 @@ class TestRunInReactor(NeedsTwistedTestCase):
         # If the given function raises an error, run_in_reactor re-raises that
         # error.
         self.assertThat(
-            lambda:self.make_spinner().run(self.make_timeout(), lambda: 1/0),
+            lambda: self.make_spinner().run(self.make_timeout(), lambda: 1/0),
             Raises(MatchesException(ZeroDivisionError)))
 
     def test_keyword_arguments(self):
@@ -162,7 +162,7 @@ class TestRunInReactor(NeedsTwistedTestCase):
         # _spinner.TimeoutError.
         timeout = self.make_timeout()
         self.assertThat(
-            lambda:self.make_spinner().run(timeout, lambda: defer.Deferred()),
+            lambda: self.make_spinner().run(timeout, lambda: defer.Deferred()),
             Raises(MatchesException(_spinner.TimeoutError)))
 
     def test_no_junk_by_default(self):
@@ -228,7 +228,8 @@ class TestRunInReactor(NeedsTwistedTestCase):
         reactor = self.make_reactor()
         spinner = self.make_spinner(reactor)
         port = spinner.run(
-            self.make_timeout(), reactor.listenTCP, 0, ServerFactory(), interface='127.0.0.1')
+            self.make_timeout(), reactor.listenTCP, 0, ServerFactory(),
+            interface='127.0.0.1')
         self.assertThat(spinner.get_junk(), Equals([port]))
 
     def test_will_not_run_with_previous_junk(self):
@@ -249,7 +250,8 @@ class TestRunInReactor(NeedsTwistedTestCase):
         reactor = self.make_reactor()
         spinner = self.make_spinner(reactor)
         timeout = self.make_timeout()
-        port = spinner.run(timeout, reactor.listenTCP, 0, ServerFactory(), interface='127.0.0.1')
+        port = spinner.run(timeout, reactor.listenTCP, 0, ServerFactory(),
+                           interface='127.0.0.1')
         junk = spinner.clear_junk()
         self.assertThat(junk, Equals([port]))
         self.assertThat(spinner.get_junk(), Equals([]))
@@ -264,7 +266,8 @@ class TestRunInReactor(NeedsTwistedTestCase):
         spinner = self.make_spinner(reactor)
         timeout = self.make_timeout()
         reactor.callLater(timeout, os.kill, os.getpid(), SIGINT)
-        self.assertThat(lambda:spinner.run(timeout * 5, defer.Deferred),
+        self.assertThat(
+            lambda: spinner.run(timeout * 5, defer.Deferred),
             Raises(MatchesException(_spinner.NoResultError)))
         self.assertEqual([], spinner._clean())
 
@@ -285,7 +288,8 @@ class TestRunInReactor(NeedsTwistedTestCase):
         spinner = self.make_spinner(reactor)
         timeout = self.make_timeout()
         reactor.callWhenRunning(os.kill, os.getpid(), SIGINT)
-        self.assertThat(lambda:spinner.run(timeout * 5, defer.Deferred),
+        self.assertThat(
+            lambda: spinner.run(timeout * 5, defer.Deferred),
             Raises(MatchesException(_spinner.NoResultError)))
         self.assertEqual([], spinner._clean())
 

--- a/testtools/tests/test_spinner.py
+++ b/testtools/tests/test_spinner.py
@@ -328,7 +328,7 @@ class TestRunInReactor(NeedsTwistedTestCase):
             return deferred2
 
         spinner2 = self.make_spinner(reactor)
-        self.assertThat(spinner2.run(3 * timeout, fire_other), Is(marker))
+        self.assertThat(spinner2.run(timeout, fire_other), Is(marker))
 
 
 def test_suite():


### PR DESCRIPTION
This was a tricky one to diagnose, but hopefully the test is straightforward and well-commented enough to explain what's going on.

I'd like to follow up with some sort of logging thing, but that's surprisingly fraught (which logger? what levels? how passed from `RunTest`? If Twisted logger, how does it interact with the users own test logs? With our tests for handling users logs?), and would also clash with #171 and #172, which are much more important, and really should land before anything of the sort.

I'd also like to fix `ADRT` to not raise `KeyboardInterrupt`, but to instead log an error and stop the run. *That's* blocked on Trial not supporting `stop`/`shouldStop` and also by #171 and #172.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/196)
<!-- Reviewable:end -->
