### PR TITLE
Fix Travis builds for pypy3 and Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,15 +31,19 @@ matrix:
       env:
         - JINJA_REQ="jinja2<2.7, Pygments<2.0"
         - SPHINX="<1.3"
+        # pip 8.0+ breaks on Python 3.2.
+        - PIP_VERSION="<8.0"
     - python: "pypy"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "pypy"
       env: TWISTED_REQ="Twisted"
     - python: "pypy3"
-      env: SPHINX="<1.3"
+      env:
+        - SPHINX="<1.3"
+        - PIP_VERSION="<8.0"
 
 install:
-  - pip install -U pip wheel setuptools
+  - pip install -U pip$PIP_VERSION wheel setuptools
   - pip install $JINJA_REQ sphinx$SPHINX $TWISTED_REQ
   - pip install .[test]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
         - SPHINX="<1.3"
         # pip 8.0+ breaks on Python 3.2.
         - PIP="<8"
-        # setuptools 19.6 breaks on Python 3.2.
+        # setuptools 19.4.1 breaks on Python 3.2.
         - SETUPTOOLS="<19.6"
     - python: "pypy"
       env: TWISTED_REQ="Twisted==13.0.0"
@@ -43,8 +43,8 @@ matrix:
       env:
         - SPHINX="<1.3"
         - PIP="<8"
-        # setuptools 19.6 breaks on Python 3.2.
-        - SETUPTOOLS="<19.6"
+        # setuptools 19.4.1 breaks on Python 3.2.
+        - SETUPTOOLS="<19.4.1"
 
 install:
   - pip install -U pip$PIP wheel setuptools$SETUPTOOLS

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - JINJA_REQ="jinja2<2.7, Pygments<2.0"
         - SPHINX="<1.3"
         # pip 8.0+ breaks on Python 3.2.
-        - PIP_VERSION="<8.0"
+        - PIP_VERSION="<8"
     - python: "pypy"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "pypy"
@@ -40,7 +40,7 @@ matrix:
     - python: "pypy3"
       env:
         - SPHINX="<1.3"
-        - PIP_VERSION="<8.0"
+        - PIP_VERSION="<8"
 
 install:
   - pip install -U pip$PIP_VERSION wheel setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ matrix:
         - JINJA_REQ="jinja2<2.7, Pygments<2.0"
         - SPHINX="<1.3"
         # pip 8.0+ breaks on Python 3.2.
-        - PIP_VERSION="<8"
+        - PIP="<8"
     - python: "pypy"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "pypy"
@@ -40,10 +40,10 @@ matrix:
     - python: "pypy3"
       env:
         - SPHINX="<1.3"
-        - PIP_VERSION="<8"
+        - PIP="<8"
 
 install:
-  - pip install -U pip$PIP_VERSION wheel setuptools
+  - pip install -U pip$PIP wheel setuptools
   - pip install $JINJA_REQ sphinx$SPHINX $TWISTED_REQ
   - pip install .[test]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
         # pip 8.0+ breaks on Python 3.2.
         - PIP="<8"
         # setuptools 19.4.1 breaks on Python 3.2.
-        - SETUPTOOLS="<19.6"
+        - SETUPTOOLS="<19.4.1"
     - python: "pypy"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "pypy"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ matrix:
         - SPHINX="<1.3"
         # pip 8.0+ breaks on Python 3.2.
         - PIP="<8"
+        # setuptools 19.6 breaks on Python 3.2.
+        - SETUPTOOLS="<19.6"
     - python: "pypy"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "pypy"
@@ -41,9 +43,11 @@ matrix:
       env:
         - SPHINX="<1.3"
         - PIP="<8"
+        # setuptools 19.6 breaks on Python 3.2.
+        - SETUPTOOLS="<19.6"
 
 install:
-  - pip install -U pip$PIP wheel setuptools
+  - pip install -U pip$PIP wheel setuptools$SETUPTOOLS
   - pip install $JINJA_REQ sphinx$SPHINX $TWISTED_REQ
   - pip install .[test]
 


### PR DESCRIPTION
Recent releases of pip 8.0 and setuptools 19.4.1 broke things for Python 3.2 and for pypy3. This PR fixes the Travis build by anchoring those dependencies accordingly.

The next release of testtools is to be the last that supports 3.2, so this is a very temporary measure.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/197)
<!-- Reviewable:end -->
