### PR TITLE
Drop support for Python 2.6 and 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,54 +1,27 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
   - "3.5"
   - "pypy"
 
-# We have to pin Jinja2 < 2.7  for Python 3.2 because 2.7 drops/breaks support:
-# http://jinja.pocoo.org/docs/changelog/#version-2-7
-# And Sphinx to < 1.3 for pypy3 and python 3.2 similarly.
-#
-# See also:
-# http://stackoverflow.com/questions/18252804/syntax-error-in-jinja-2-library
-#
 # Twisted tests currently only work on Python 2.
 matrix:
   include:
-    - python: "2.6"
-      env: TWISTED_REQ="Twisted==13.0.0"
-    - python: "2.6"
-      # Last version that supports Python 2.6.
-      env: TWISTED_REQ="Twisted==15.4.0"
     - python: "2.7"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "2.7"
       env: TWISTED_REQ="Twisted"
-    - python: "3.2"
-      env:
-        - JINJA_REQ="jinja2<2.7, Pygments<2.0"
-        - SPHINX="<1.3"
-        # pip 8.0+ breaks on Python 3.2.
-        - PIP="<8"
-        # setuptools 19.4.1 breaks on Python 3.2.
-        - SETUPTOOLS="<19.4.1"
     - python: "pypy"
       env: TWISTED_REQ="Twisted==13.0.0"
     - python: "pypy"
       env: TWISTED_REQ="Twisted"
-    - python: "pypy3"
-      env:
-        - SPHINX="<1.3"
-        - PIP="<8"
-        # setuptools 19.4.1 breaks on Python 3.2.
-        - SETUPTOOLS="<19.4.1"
 
 install:
-  - pip install -U pip$PIP wheel setuptools$SETUPTOOLS
-  - pip install $JINJA_REQ sphinx$SPHINX $TWISTED_REQ
+  - pip install -U pip wheel setuptools
+  - pip install sphinx $TWISTED_REQ
   - pip install .[test]
 
 script:

--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,16 @@ testtools NEWS
 
 Changes and improvements to testtools_, grouped by release.
 
+Next
+~~~~
+
+Changes
+-------
+
+* Python 2.6 and 3.2 support now gone. If you want to use either of these versions of
+  Python, use testtools 1.9.0.  (Jonathan Lange)
+
+
 1.9.0
 ~~~~~
 

--- a/NEWS
+++ b/NEWS
@@ -9,8 +9,8 @@ Next
 Changes
 -------
 
-* Python 2.6 and 3.2 support now gone. If you want to use either of these versions of
-  Python, use testtools 1.9.0.  (Jonathan Lange)
+* Python 2.6 and 3.2 are no longer supported. If you want to use either of
+  these versions of Python, use testtools 1.9.0. (Jonathan Lange)
 
 
 1.9.0

--- a/README.rst
+++ b/README.rst
@@ -28,26 +28,22 @@ copyright Steve Purcell and the Python Software Foundation, it is distributed
 under the same license as Python, see LICENSE for details.
 
 
-Required Dependencies
----------------------
+Supported platforms
+-------------------
 
- * Python 2.6+ or 3.2+ / pypy (2.x+)
+ * Python 2.7+ or 3.3+ / pypy (2.x+)
 
-If you would like to use testtools for earlier Python's, please use testtools
-0.9.15.
+If you would like to use testtools for earlier Pythons, please use testtools
+1.9.0, or for *really* old Pythons, testtools 0.9.15.
 
- * extras (helpers that we intend to push into Python itself in the near
-   future).
-
- * The most recent unittest2 (backports of the latest unittest API from
-   cPython, which we use to avoid code duplication).
+testtools probably works on all OSes that Python works on, but is most heavily
+tested on Linux and OS X.
 
 
 Optional Dependencies
 ---------------------
 
-If you would like to use our undocumented, unsupported Twisted support, then
-you will need Twisted.
+If you would like to use our Twisted support, then you will need Twisted.
 
 If you want to use ``fixtures`` then you can either install fixtures (e.g. from
 https://launchpad.net/python-fixtures or http://pypi.python.org/pypi/fixtures)

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -4,8 +4,7 @@ testtools: tasteful testing for Python
 
 testtools is a set of extensions to the Python standard library's unit testing
 framework. These extensions have been derived from many years of experience
-with unit testing in Python and come from many different sources. testtools
-supports Python versions all the way back to Python 2.6.
+with unit testing in Python and come from many different sources.
 
 What better way to start than with a contrived code snippet?::
 
@@ -93,9 +92,10 @@ Cross-Python compatibility
 --------------------------
 
 testtools gives you the very latest in unit testing technology in a way that
-will work with Python 2.6, 2.7, 3.2, 3.3, 3.4, and 3.5.
+will work with Python 2.7, 3.3, 3.4, 3.5, and pypy.
 
 If you wish to use testtools with Python 2.4 or 2.5, then please use testtools
-0.9.15. Up to then we supported Python 2.4 and 2.5, but we found the
-constraints involved in not using the newer language features onerous as we
-added more support for versions post Python 3.
+0.9.15.
+
+If you wish to use testtools with Python 2.6 or 3.2, then please use testtools
+1.9.0.


### PR DESCRIPTION
Just the tests and documentation for now. Leaves any code accommodations in place.

Means we can simplify the Travis configuration quite a lot.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/198)
<!-- Reviewable:end -->
