### PR TITLE
Use `skipTest` instead of `skip`

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -19,7 +19,6 @@ import copy
 import functools
 import itertools
 import sys
-import types
 import warnings
 
 from extras import (
@@ -40,7 +39,6 @@ from testtools.compat import (
 from testtools.matchers import (
     Annotate,
     Contains,
-    Equals,
     MatchesAll,
     MatchesException,
     MismatchError,
@@ -59,6 +57,7 @@ from testtools.testresult import (
 
 wraps = try_import('functools.wraps')
 
+
 class TestSkipped(Exception):
     """Raised within TestCase.run() when a test is skipped."""
 TestSkipped = try_import('unittest.case.SkipTest', TestSkipped)
@@ -75,6 +74,7 @@ _UnexpectedSuccess = try_import(
     'unittest.case._UnexpectedSuccess', _UnexpectedSuccess)
 _UnexpectedSuccess = try_import(
     'unittest2.case._UnexpectedSuccess', _UnexpectedSuccess)
+
 
 class _ExpectedFailure(Exception):
     """An expected failure occured.
@@ -420,12 +420,14 @@ class TestCase(unittest.TestCase):
             def match(self, matchee):
                 if not issubclass(matchee[0], excClass):
                     reraise(*matchee)
+
         class CaptureMatchee(object):
             def match(self, matchee):
                 self.matchee = matchee[1]
         capture = CaptureMatchee()
-        matcher = Raises(MatchesAll(ReRaiseOtherTypes(),
-                MatchesException(excClass), capture))
+        matcher = Raises(
+            MatchesAll(ReRaiseOtherTypes(),
+                       MatchesException(excClass), capture))
         our_callable = Nullary(callableObj, *args, **kwargs)
         self.assertThat(our_callable, matcher)
         return capture.matchee
@@ -467,13 +469,14 @@ class TestCase(unittest.TestCase):
         """Check that matchee is matched by matcher, but delay the assertion failure.
 
         This method behaves similarly to ``assertThat``, except that a failed
-        match does not exit the test immediately. The rest of the test code will
-        continue to run, and the test will be marked as failing after the test
-        has finished.
+        match does not exit the test immediately. The rest of the test code
+        will continue to run, and the test will be marked as failing after the
+        test has finished.
 
         :param matchee: An object to match with matcher.
         :param matcher: An object meeting the testtools.Matcher protocol.
         :param message: If specified, show this message with any failed match.
+
         """
         mismatch_error = self._matchHelper(matchee, matcher, message, verbose)
 
@@ -555,7 +558,7 @@ class TestCase(unittest.TestCase):
         return '%s-%d' % (prefix, self.getUniqueInteger())
 
     def onException(self, exc_info, tb_label='traceback'):
-        """Called when an exception propogates from test code.
+        """Called when an exception propagates from test code.
 
         :seealso addOnException:
         """
@@ -806,7 +809,8 @@ def ErrorHolder(test_id, error, short_description=None, details=None):
     :param short_description: An optional short description of the test.
     :param details: Outcome details as accepted by addSuccess etc.
     """
-    return PlaceHolder(test_id, short_description=short_description,
+    return PlaceHolder(
+        test_id, short_description=short_description,
         details=details, outcome='addError', error=error)
 
 
@@ -901,6 +905,7 @@ def skipIf(condition, reason):
     """A decorator to skip a test if the condition is true."""
     if condition:
         return skip(reason)
+
     def _id(obj):
         return obj
     return _id
@@ -910,6 +915,7 @@ def skipUnless(condition, reason):
     """A decorator to skip a test unless the condition is true."""
     if not condition:
         return skip(reason)
+
     def _id(obj):
         return obj
     return _id

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1295,14 +1295,16 @@ require_py27_minimum = skipIf(
 class TestSkipping(TestCase):
     """Tests for skipping of tests functionality."""
 
-    run_test_with = FullStackRunTest
+    run_tests_with = FullStackRunTest
 
     def test_skip_causes_skipException(self):
-        self.assertThat(lambda:self.skip("Skip this test"),
+        self.assertThat(
+            lambda: self.skip("Skip this test"),
             Raises(MatchesException(self.skipException)))
 
     def test_can_use_skipTest(self):
-        self.assertThat(lambda:self.skipTest("Skip this test"),
+        self.assertThat(
+            lambda: self.skipTest("Skip this test"),
             Raises(MatchesException(self.skipException)))
 
     def test_skip_without_reason_works(self):
@@ -1313,14 +1315,16 @@ class TestSkipping(TestCase):
         result = ExtendedTestResult()
         case.run(result)
         self.assertEqual('addSkip', result._events[1][0])
-        self.assertEqual('no reason given.',
+        self.assertEqual(
+            'no reason given.',
             result._events[1][2]['reason'].as_text())
 
     def test_skipException_in_setup_calls_result_addSkip(self):
         class TestThatRaisesInSetUp(TestCase):
             def setUp(self):
                 TestCase.setUp(self)
-                self.skip("skipping this test")
+                self.skipTest("skipping this test")
+
             def test_that_passes(self):
                 pass
         calls = []
@@ -1328,72 +1332,103 @@ class TestSkipping(TestCase):
         test = TestThatRaisesInSetUp("test_that_passes")
         test.run(result)
         case = result._events[0][1]
-        self.assertEqual([('startTest', case),
-            ('addSkip', case, "skipping this test"), ('stopTest', case)],
+        self.assertEqual(
+            [('startTest', case),
+             ('addSkip', case, "skipping this test"),
+             ('stopTest', case)],
             calls)
 
     def test_skipException_in_test_method_calls_result_addSkip(self):
         class SkippingTest(TestCase):
             def test_that_raises_skipException(self):
-                self.skip("skipping this test")
-        result = Python27TestResult()
+                self.skipTest("skipping this test")
+        events = []
+        result = Python27TestResult(events)
         test = SkippingTest("test_that_raises_skipException")
         test.run(result)
         case = result._events[0][1]
-        self.assertEqual([('startTest', case),
-            ('addSkip', case, "skipping this test"), ('stopTest', case)],
-            result._events)
+        self.assertEqual(
+            [('startTest', case),
+             ('addSkip', case, "skipping this test"),
+             ('stopTest', case)],
+            events)
+
+    def test_different_skipException_in_test_method_calls_result_addSkip(self):
+        class SkippingTest(TestCase):
+            skipException = ValueError
+
+            def test_that_raises_skipException(self):
+                self.skipTest("skipping this test")
+
+        events = []
+        result = Python27TestResult(events)
+        test = SkippingTest("test_that_raises_skipException")
+        test.run(result)
+        case = result._events[0][1]
+        self.assertEqual(
+            [('startTest', case),
+             ('addSkip', case, "skipping this test"),
+             ('stopTest', case)],
+            events)
 
     def test_skip__in_setup_with_old_result_object_calls_addSuccess(self):
+
         class SkippingTest(TestCase):
             def setUp(self):
                 TestCase.setUp(self)
                 raise self.skipException("skipping this test")
+
             def test_that_raises_skipException(self):
                 pass
-        result = Python26TestResult()
+
+        events = []
+        result = Python26TestResult(events)
         test = SkippingTest("test_that_raises_skipException")
         test.run(result)
-        self.assertEqual('addSuccess', result._events[1][0])
+        self.assertEqual('addSuccess', events[1][0])
 
     def test_skip_with_old_result_object_calls_addError(self):
         class SkippingTest(TestCase):
             def test_that_raises_skipException(self):
                 raise self.skipException("skipping this test")
-        result = Python26TestResult()
+        events = []
+        result = Python26TestResult(events)
         test = SkippingTest("test_that_raises_skipException")
         test.run(result)
-        self.assertEqual('addSuccess', result._events[1][0])
+        self.assertEqual('addSuccess', events[1][0])
 
     def test_skip_decorator(self):
         class SkippingTest(TestCase):
             @skip("skipping this test")
             def test_that_is_decorated_with_skip(self):
                 self.fail()
-        result = Python26TestResult()
+        events = []
+        result = Python26TestResult(events)
         test = SkippingTest("test_that_is_decorated_with_skip")
         test.run(result)
-        self.assertEqual('addSuccess', result._events[1][0])
+        self.assertEqual('addSuccess', events[1][0])
 
     def test_skipIf_decorator(self):
         class SkippingTest(TestCase):
             @skipIf(True, "skipping this test")
             def test_that_is_decorated_with_skipIf(self):
                 self.fail()
-        result = Python26TestResult()
+        events = []
+        result = Python26TestResult(events)
         test = SkippingTest("test_that_is_decorated_with_skipIf")
         test.run(result)
-        self.assertEqual('addSuccess', result._events[1][0])
+        self.assertEqual('addSuccess', events[1][0])
 
     def test_skipUnless_decorator(self):
         class SkippingTest(TestCase):
             @skipUnless(False, "skipping this test")
             def test_that_is_decorated_with_skipUnless(self):
                 self.fail()
-        result = Python26TestResult()
+        events = []
+        result = Python26TestResult(events)
         test = SkippingTest("test_that_is_decorated_with_skipUnless")
         test.run(result)
-        self.assertEqual('addSuccess', result._events[1][0])
+        self.assertEqual('addSuccess', events[1][0])
 
     def check_skip_decorator_does_not_run_setup(self, decorator, reason):
         class SkippingTest(TestCase):


### PR DESCRIPTION
`skip` is deprecated, so updates tests to use `skipTest`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/201)
<!-- Reviewable:end -->
