### PR TITLE
Disable Twisted debugging in some tests

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,9 @@ Changes
 * Python 2.6 and 3.2 are no longer supported. If you want to use either of
   these versions of Python, use testtools 1.9.0. (Jonathan Lange)
 
+* Make ``fixtures`` a real dependency, not just a test dependency.
+  (Jonathan Lange)
+
 
 1.9.0
 ~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pbr>=0.11
 extras
+fixtures
 pyrsistent
 # 'mimeparse' has not been uploaded by the maintainer with Python3 compat
 # but someone kindly uploaded a fixed version as 'python-mimeparse'.

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,6 @@ classifier =
 
 [extras]
 test =
-  fixtures
   testscenarios
   unittest2>=1.1.0
 

--- a/testtools/_deferreddebug.py
+++ b/testtools/_deferreddebug.py
@@ -1,0 +1,23 @@
+# Copyright (c) testtools developers. See LICENSE for details.
+#
+# TODO: Move this to testtools.twistedsupport. See testing-cabal/testtools#202.
+
+from fixtures import Fixture, MonkeyPatch
+
+
+class DebugTwisted(Fixture):
+    """
+    Set debug options for Twisted.
+    """
+
+    def __init__(self, debug=True):
+        super(DebugTwisted, self).__init__()
+        self._debug_setting = debug
+
+    def _setUp(self):
+        self.useFixture(
+            MonkeyPatch('twisted.internet.defer.Deferred.debug',
+                        self._debug_setting))
+        self.useFixture(
+            MonkeyPatch('twisted.internet.base.DelayedCall.debug',
+                        self._debug_setting))

--- a/testtools/_spinner.py
+++ b/testtools/_spinner.py
@@ -16,12 +16,12 @@ __all__ = [
     'trap_unhandled_errors',
     ]
 
+from fixtures import Fixture
 import signal
 
-from testtools.monkey import MonkeyPatcher
+from testtools._deferreddebug import DebugTwisted
 
 from twisted.internet import defer
-from twisted.internet.base import DelayedCall
 from twisted.internet.interfaces import IReactorThreads
 from twisted.python.failure import Failure
 from twisted.python.util import mergeFunctionMetadata
@@ -265,12 +265,12 @@ class Spinner(object):
         :return: Whatever is at the end of the function's callback chain.  If
             it's an error, then raise that.
         """
-        debug = MonkeyPatcher()
         if self._debug:
-            debug.add_patch(defer.Deferred, 'debug', True)
-            debug.add_patch(DelayedCall, 'debug', True)
-        debug.patch()
-        try:
+            debug_settings = DebugTwisted(True)
+        else:
+            debug_settings = Fixture()
+
+        with debug_settings:
             junk = self.get_junk()
             if junk:
                 raise StaleJunkError(junk)
@@ -300,5 +300,3 @@ class Spinner(object):
                 return self._get_result()
             finally:
                 self._clean()
-        finally:
-            debug.restore()

--- a/testtools/tests/test_deferredruntest.py
+++ b/testtools/tests/test_deferredruntest.py
@@ -12,6 +12,7 @@ from testtools import (
     TestCase,
     TestResult,
     )
+from testtools._deferreddebug import DebugTwisted
 from testtools.matchers import (
     ContainsAll,
     EndsWith,
@@ -381,6 +382,10 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
     def test_unhandled_error_from_deferred(self):
         # If there's a Deferred with an unhandled error, the test fails.  Each
         # unhandled error is reported with a separate traceback.
+
+        # We're interested in the behavior when debugging is disabled. When
+        # debugging is enabled, we get more stack traces.
+        self.useFixture(DebugTwisted(False))
         class SomeCase(TestCase):
             def test_cruft(self):
                 # Note we aren't returning the Deferred so that the error will
@@ -408,6 +413,10 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
         # If there's a Deferred with an unhandled error, the test fails.  Each
         # unhandled error is reported with a separate traceback, and the error
         # is still reported.
+
+        # We're interested in the behavior when debugging is disabled. When
+        # debugging is enabled, we get more stack traces.
+        self.useFixture(DebugTwisted(False))
         class SomeCase(TestCase):
             def test_cruft(self):
                 # Note we aren't returning the Deferred so that the error will
@@ -566,6 +575,10 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
     def test_only_addError_once(self):
         # Even if the reactor is unclean and the test raises an error and the
         # cleanups raise errors, we only called addError once per test.
+
+        # We're interested in the behavior when debugging is disabled. When
+        # debugging is enabled, we get more stack traces.
+        self.useFixture(DebugTwisted(False))
         reactor = self.make_reactor()
         class WhenItRains(TestCase):
             def it_pours(self):


### PR DESCRIPTION
Some of our tests assume that debugging is not enabled in Twisted. This makes that assumption explicit by disabling debugging for the duration of the test.

It does this by:
* changing the spinner to use a custom MonkeyPatch fixture, rather than testtools monkey patch
* making the fixture explicitly set debugging bools to a value (rather than hardcoding true or false)
* using a fixture always, but only the identity fixture (`Fixture`) when debugging is not set
* updating the relevant tests to use `DebugTwisted(False)`

Testing strategy has been to run tests with `trial --debug-stacktraces`. I don't think we need explicit tests for the debugging behavior. There are other issues preventing trial from running in full (due to Trial's weird reporter API), but that's a separate PR for another time.

Will conflict with #171, which also adds fixtures as a dependency, and (in spirit) with #202, which moves all Twisted code to its own package.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/204)
<!-- Reviewable:end -->
