### PR TITLE
[205] Tests to demonstrate that skipIf can be used to decorate a TestCase and setUp methods

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -878,14 +878,16 @@ def skip(reason):
         # attributes.
         test_item.__unittest_skip__ = True
         test_item.__unittest_skip_why__ = reason
-        if wraps is not None:
-            @wraps(test_item)
-            def skip_wrapper(*args, **kwargs):
-                raise TestCase.skipException(reason)
-        else:
-            def skip_wrapper(test_item):
-                test_item.skip(reason)
-        return skip_wrapper
+        if not isinstance(test_item, (type, types.ClassType)):
+            if wraps is not None:
+                @wraps(test_item)
+                def skip_wrapper(*args, **kwargs):
+                    raise TestCase.skipException(reason)
+            else:
+                def skip_wrapper(test_item):
+                    test_item.skip(reason)
+            test_item = skip_wrapper
+        return test_item
     return decorator
 
 

--- a/testtools/tests/test_skip.py
+++ b/testtools/tests/test_skip.py
@@ -1,0 +1,63 @@
+"""
+Note that the testtools.skipIf decorated testtools.TestCase doesn't show up in
+the results when run with trial.
+
+$ trial testtools.tests.test_skip
+testtools.tests.test_skip
+  TestCaseWithUnittest
+    test_skip ...                                                     [SKIPPED]
+
+===============================================================================
+[SKIPPED]
+TestCase skipped
+
+testtools.tests.test_skip.TestCaseWithUnittest.test_skip
+-------------------------------------------------------------------------------
+Ran 1 tests in 0.015s
+
+PASSED (skips=1)
+
+And when I attempt to run the testtools TestCase directly I get the following error:
+
+$ trial testtools.tests.test_skip.TestCaseWithTesttools
+Traceback (most recent call last):
+  File "/home/richard/.virtualenvs/testtools-205/bin/trial", line 22, in <module>
+    run()
+  File "/home/richard/.virtualenvs/testtools-205/lib/python2.7/site-packages/twisted/scripts/trial.py", line 612, in run
+    suite = _getSuite(config)
+  File "/home/richard/.virtualenvs/testtools-205/lib/python2.7/site-packages/twisted/scripts/trial.py", line 500, in _getSuite
+    return loader.loadByNames(config['tests'], recurse=recurse)
+  File "/home/richard/.virtualenvs/testtools-205/lib/python2.7/site-packages/twisted/trial/runner.py", line 609, in loadByNames
+    for thing in self._uniqueTests(things)]
+  File "/home/richard/.virtualenvs/testtools-205/lib/python2.7/site-packages/twisted/trial/runner.py", line 573, in loadAnything
+    raise TypeError("No loader for %r. Unrecognized type" % (thing,))
+TypeError: No loader for <function TestCaseWithTesttools at 0x7f71d6406aa0>. Unrecognized type
+
+"""
+
+from unittest import (
+    TestCase as UnittestTestCase,
+    skipIf as unittest_skipIf,
+)
+from testtools import (
+    TestCase as TesttoolsTestCase,
+    skipIf as testtools_skipIf,
+)
+
+
+@testtools_skipIf(True, "TestCase skipped")
+class TestCaseWithTesttools(TesttoolsTestCase):
+    """
+    This TestCase doesn't show.
+    """
+    def test_skip(self):
+        self.fail("This shouldn't run")
+
+
+@unittest_skipIf(True, "TestCase skipped")
+class TestCaseWithUnittest(UnittestTestCase):
+    """
+    This TestCase shows as skipped.
+    """
+    def test_skip(self):
+        self.fail("This shouldn't run")

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1365,6 +1365,34 @@ class TestSkipping(TestCase):
         test.run(result)
         self.assertEqual('addSuccess', result._events[1][0])
 
+    def test_skipIf_class_decorator(self):
+        """
+        ``skipIf`` can be used as a class decorator.
+        """
+        @skipIf(True, "skipping this test")
+        class SkippingTest(TestCase):
+            def test_in_a_skipped_testcase(self):
+                self.fail()
+        result = Python26TestResult()
+        test = SkippingTest("test_in_a_skipped_testcase")
+        test.run(result)
+        self.assertEqual('addSuccess', result._events[1][0])
+
+    def test_skipIf_setup_decorator(self):
+        """
+        When ``skipIf`` is used to decorate ``setUp`` all tests are skipped.
+        """
+        class SkippingTest(TestCase):
+            @skipIf(True, "skipping this test")
+            def setUp(self):
+                pass
+            def test_that_triggers_a_skipped_setup(self):
+                self.fail()
+        result = Python26TestResult()
+        test = SkippingTest("test_that_triggers_a_skipped_setup")
+        test.run(result)
+        self.assertEqual('addSuccess', result._events[1][0])
+
     def test_skipUnless_decorator(self):
         class SkippingTest(TestCase):
             @skipUnless(False, "skipping this test")


### PR DESCRIPTION
Demonstrates: https://github.com/testing-cabal/testtools/issues/205

The testtools.tests.test_testcase skip tests don't reveal the problem.

But tests  in testtools.tests.test_skip, which are decorated and run directly do demonstrate the problem.

Perhaps the testtools skip tests are not checking that the tests are marked as skipped...only that they are not run....which in this case seems to be because the decorated TestCase becomes a function rather than a class.

```
(testtools-205)(skip-class-205 ✕✓ =)[~/.../HybridLogic/testtools]$ trial testtools.tests.test_skip.TestCaseWithTesttools
Traceback (most recent call last):
  File "/home/richard/.virtualenvs/testtools-205/bin/trial", line 22, in <module>
    run()
  File "/home/richard/.virtualenvs/testtools-205/lib/python2.7/site-packages/twisted/scripts/trial.py", line 612, in run
    suite = _getSuite(config)
  File "/home/richard/.virtualenvs/testtools-205/lib/python2.7/site-packages/twisted/scripts/trial.py", line 500, in _getSuite
    return loader.loadByNames(config['tests'], recurse=recurse)
  File "/home/richard/.virtualenvs/testtools-205/lib/python2.7/site-packages/twisted/trial/runner.py", line 609, in loadByNames
    for thing in self._uniqueTests(things)]
  File "/home/richard/.virtualenvs/testtools-205/lib/python2.7/site-packages/twisted/trial/runner.py", line 573, in loadAnything
    raise TypeError("No loader for %r. Unrecognized type" % (thing,))
TypeError: No loader for <function TestCaseWithTesttools at 0x7f71d6406aa0>. Unrecognized type

```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/206)

<!-- Reviewable:end -->
