### PR TITLE
Fix example in docstring for `failed`

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,8 @@ Improvements
 
 * New ``Always`` and ``Never`` matchers. (Tristan Seligmann, #947026)
 
+* Fixed example in ``failed`` docstring. (Jonathan Lange, Github #208)
+
 2.0.0
 ~~~~~
 

--- a/testtools/twistedsupport/_matchers.py
+++ b/testtools/twistedsupport/_matchers.py
@@ -164,7 +164,8 @@ def failed(matcher):
     For example::
 
         error = RuntimeError('foo')
-        fails_at_runtime = failed(Equals(error))
+        fails_at_runtime = failed(
+            AfterPreprocessing(lambda f: f.value, Equals(error)))
         deferred = defer.fail(error)
         assert_that(deferred, fails_at_runtime)
 


### PR DESCRIPTION
Fix for #208

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/212)
<!-- Reviewable:end -->
