### PR TITLE
Revert usage of pyrsistent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 pbr>=0.11
 extras
 fixtures>=1.3.0
-pyrsistent
 # 'mimeparse' has not been uploaded by the maintainer with Python3 compat
 # but someone kindly uploaded a fixed version as 'python-mimeparse'.
 python-mimeparse


### PR DESCRIPTION
Remove the dependency on pyrsistent and make the _TestRecord class a
simple object, as it has a pretty big performance hit.

Closes #219

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/221)
<!-- Reviewable:end -->
