### PR TITLE
Correct docs for skip deprecation

### DIFF
--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -1285,7 +1285,6 @@ from testtools, you do not have to worry about this.
 
 In older versions of testtools, ``skipTest`` was known as ``skip``. Since
 Python 2.7 added ``skipTest`` support, the ``skip`` name is now deprecated.
-No warning is emitted yet – some time in the future we may do so.
 
 
 addOnException


### PR DESCRIPTION
The docs said that the skip method didn't emit a warning, but it
does since 9e43c3c.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/226)
<!-- Reviewable:end -->
