### PR TITLE
Encode the captured Twisted logs.

### DIFF
--- a/testtools/twistedsupport/_runtest.py
+++ b/testtools/twistedsupport/_runtest.py
@@ -173,8 +173,8 @@ class CaptureTwistedLogs(Fixture):
         logs = StringIO()
         full_observer = log.FileLogObserver(logs)
         self.useFixture(_TwistedLogObservers([full_observer.emit]))
-        self.addDetail(self.LOG_DETAIL_NAME,
-                       Content(UTF8_TEXT, lambda: [logs.getvalue()]))
+        self.addDetail(self.LOG_DETAIL_NAME, Content(
+            UTF8_TEXT, lambda: [logs.getvalue().encode("utf-8")]))
 
 
 def run_with_log_observers(observers, function, *args, **kwargs):


### PR DESCRIPTION
The existing test for this (``TestCaptureTwistedLogs.test_captures_logs``) is sufficient; it fails already without this change. Fixes #230.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/231)
<!-- Reviewable:end -->
