### PR TITLE
Unbreak fixtures test suite / use of gather_details

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pbr>=0.11
-extras
+extras>=1.0.0
 fixtures>=1.3.0
 # 'mimeparse' has not been uploaded by the maintainer with Python3 compat
 # but someone kindly uploaded a fixed version as 'python-mimeparse'.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -27,7 +27,6 @@ from extras import (
     try_import,
     try_imports,
     )
-fixtures = try_import('fixtures')
 # To let setup.py work, make this a conditional import.
 unittest = try_imports(['unittest2', 'unittest'])
 import six
@@ -182,6 +181,12 @@ def gather_details(source_dict, target_dict):
             new_name = '%s-%d' % (name, advance_iterator(disambiguator))
         name = new_name
         target_dict[name] = _copy_content(content_object)
+
+
+# Circular import: fixtures imports gather_details from here, we import
+# fixtures, leading to gather_details not being available and fixtures being
+# unable to import it.
+fixtures = try_import('fixtures')
 
 
 def _mods(i, mod):


### PR DESCRIPTION
There is a circular import loop between testtools and fixtures,
which is fine, but we need to define gather_details before importing
fixtures.

Change-Id: I9a59968c4e2ac2c29d679d7f5c474696c898671e

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/232)
<!-- Reviewable:end -->
