### PR TITLE
Make KeysEqual usable with no arguments, i.e. match a dict with no keys.

### DIFF
--- a/testtools/matchers/_dict.py
+++ b/testtools/matchers/_dict.py
@@ -4,6 +4,8 @@ __all__ = [
     'KeysEqual',
     ]
 
+from collections import Mapping
+
 from ..helpers import (
     dict_subtract,
     filter_values,
@@ -235,15 +237,15 @@ class KeysEqual(Matcher):
     def __init__(self, *expected):
         """Create a `KeysEqual` Matcher.
 
-        :param expected: The keys the dict is expected to have.  If a dict,
-            then we use the keys of that dict, if a collection, we assume it
-            is a collection of expected keys.
+        :param expected: The keys the matchee is expected to have. As a
+            special case, if a single argument is specified, and it is a
+            mapping, then we use its keys as the expected set.
         """
         super(KeysEqual, self).__init__()
-        try:
+        if len(expected) == 1 and isinstance(expected[0], Mapping):
             self.expected = expected[0].keys()
-        except AttributeError:
-            self.expected = list(expected)
+        else:
+            self.expected = expected
 
     def __str__(self):
         return "KeysEqual(%s)" % ', '.join(map(repr, self.expected))

--- a/testtools/matchers/_dict.py
+++ b/testtools/matchers/_dict.py
@@ -4,8 +4,6 @@ __all__ = [
     'KeysEqual',
     ]
 
-from collections import Mapping
-
 from ..helpers import (
     dict_subtract,
     filter_values,
@@ -242,10 +240,12 @@ class KeysEqual(Matcher):
             mapping, then we use its keys as the expected set.
         """
         super(KeysEqual, self).__init__()
-        if len(expected) == 1 and isinstance(expected[0], Mapping):
-            self.expected = expected[0].keys()
-        else:
-            self.expected = expected
+        if len(expected) == 1:
+            try:
+                expected = expected[0].keys()
+            except AttributeError:
+                pass
+        self.expected = list(expected)
 
     def __str__(self):
         return "KeysEqual(%s)" % ', '.join(map(repr, self.expected))

--- a/testtools/tests/matchers/test_dict.py
+++ b/testtools/tests/matchers/test_dict.py
@@ -30,6 +30,30 @@ class TestMatchesAllDictInterface(TestCase, TestMatchersInterface):
         ]
 
 
+class TestKeysEqualEmpty(TestCase, TestMatchersInterface):
+
+    matches_matcher = KeysEqual()
+    matches_matches = [
+        {},
+        ]
+    matches_mismatches = [
+        {'foo': 0, 'bar': 1},
+        {'foo': 0},
+        {'bar': 1},
+        {'foo': 0, 'bar': 1, 'baz': 2},
+        {'a': None, 'b': None, 'c': None},
+        ]
+
+    str_examples = [
+        ("KeysEqual()", KeysEqual()),
+        ]
+
+    describe_examples = [
+        ("[] does not match {1: 2}: Keys not equal",
+         {1: 2}, matches_matcher),
+        ]
+
+
 class TestKeysEqualWithList(TestCase, TestMatchersInterface):
 
     matches_matcher = KeysEqual('foo', 'bar')


### PR DESCRIPTION
<!-- Reviewable:start -->

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testtools/241)

<!-- Reviewable:end -->
