### PR TITLE
Make twistedsupport and related tests fully work on Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,21 +7,9 @@ python:
   - "3.5"
   - "pypy"
 
-# Twisted tests currently only work on Python 2.
-matrix:
-  include:
-    - python: "2.7"
-      env: TWISTED_REQ="Twisted==13.0.0"
-    - python: "2.7"
-      env: TWISTED_REQ="Twisted"
-    - python: "pypy"
-      env: TWISTED_REQ="Twisted==13.0.0"
-    - python: "pypy"
-      env: TWISTED_REQ="Twisted"
-
 install:
   - pip install -U pip wheel setuptools
-  - pip install sphinx $TWISTED_REQ
+  - pip install sphinx Twisted
   - pip install .[test]
 
 script:

--- a/testtools/tests/twistedsupport/test_spinner.py
+++ b/testtools/tests/twistedsupport/test_spinner.py
@@ -137,8 +137,8 @@ class TestRunInReactor(NeedsTwistedTestCase):
 
     def test_preserve_signal_handler(self):
         signals = ['SIGINT', 'SIGTERM', 'SIGCHLD']
-        signals = filter(
-            None, (getattr(signal, name, None) for name in signals))
+        signals = list(filter(
+            None, (getattr(signal, name, None) for name in signals)))
         for sig in signals:
             self.addCleanup(signal.signal, sig, signal.getsignal(sig))
         new_hdlrs = list(lambda *a: None for _ in signals)
@@ -146,7 +146,7 @@ class TestRunInReactor(NeedsTwistedTestCase):
             signal.signal(sig, hdlr)
         spinner = self.make_spinner()
         spinner.run(self.make_timeout(), lambda: None)
-        self.assertEqual(new_hdlrs, map(signal.getsignal, signals))
+        self.assertItemsEqual(new_hdlrs, list(map(signal.getsignal, signals)))
 
     def test_timeout(self):
         # If the function takes too long to run, we raise a

--- a/testtools/twistedsupport/_spinner.py
+++ b/testtools/twistedsupport/_spinner.py
@@ -19,6 +19,8 @@ __all__ = [
 from fixtures import Fixture
 import signal
 
+import six
+
 from ._deferreddebug import DebugTwisted
 
 from twisted.internet import defer
@@ -68,10 +70,31 @@ def trap_unhandled_errors(function, *args, **kwargs):
     """
     real_DebugInfo = defer.DebugInfo
     debug_infos = []
-    def DebugInfo():
-        info = real_DebugInfo()
-        debug_infos.append(info)
-        return info
+
+    # Apparently the fact that Twisted now decorates DebugInfo with @_oldStyle
+    # screws up things a bit for us here: monkey patching the __del__ method on
+    # an instance doesn't work with Python 3 and viceversa overriding __del__
+    # via inheritance doesn't work with Python 2. So we handle the two cases
+    # differently. TODO: perhaps there's a way to have a single code path?
+    if six.PY2:
+        def DebugInfo():
+            info = real_DebugInfo()
+            debug_infos.append(info)
+            return info
+    else:
+
+        class DebugInfo(real_DebugInfo):
+
+            _runRealDel = True
+
+            def __init__(self):
+                real_DebugInfo.__init__(self)
+                debug_infos.append(self)
+
+            def __del__(self):
+                if self._runRealDel:
+                    real_DebugInfo.__del__(self)
+
     defer.DebugInfo = DebugInfo
     try:
         result = function(*args, **kwargs)
@@ -83,7 +106,10 @@ def trap_unhandled_errors(function, *args, **kwargs):
             errors.append(info)
             # Disable the destructor that logs to error. We are already
             # catching the error here.
-            info.__del__ = lambda: None
+            if six.PY2:
+                info.__del__ = lambda: None
+            else:
+                info._runRealDel = False
     return result, errors
 
 


### PR DESCRIPTION
Now that Python 3 support in Twisted is mature enough, we can have testtools.twistedsupport fully working with Python 3.

This branch fixes some of the magic in _spinner.trap_unhandled_errors (which did not work in with Python 3, as test failures showed), so the suite is now fully green on Python 3:

$ python3 -m testtools.run testtools.tests.test_suite
Tests running...

Ran 2612 tests in 1.311s
OK

$ python -m testtools.run testtools.tests.test_suite
Tests running...

Ran 2612 tests in 1.253s
OK

The hard-coded test dependency on Twisted 13 has been removed as well.