### PR TITLE
Making sure that TestCase can be hashed

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -276,11 +276,8 @@ class TestCase(unittest.TestCase):
         return self.__dict__ == other.__dict__
 
     def __hash__(self):
-        hashfn = getattr(unittest.TestCase, '__hash__', None)
-        if hashfn is not None:
-            return hashfn(self)
-        return id(self)
-
+        hashfn = getattr(unittest.TestCase, '__hash__', id)
+        return hashfn(self)
 
     def __repr__(self):
         # We add id to the repr because it makes testing testtools easier.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -275,9 +275,7 @@ class TestCase(unittest.TestCase):
             return False
         return self.__dict__ == other.__dict__
 
-    def __hash__(self):
-        hashfn = getattr(unittest.TestCase, '__hash__', id)
-        return hashfn(self)
+    __hash__ = unittest.TestCase.__hash__
 
     def __repr__(self):
         # We add id to the repr because it makes testing testtools easier.

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -275,6 +275,13 @@ class TestCase(unittest.TestCase):
             return False
         return self.__dict__ == other.__dict__
 
+    def __hash__(self):
+        hashfn = getattr(unittest.TestCase, '__hash__', None)
+        if hashfn is not None:
+            return hashfn(self)
+        return id(self)
+
+
     def __repr__(self):
         # We add id to the repr because it makes testing testtools easier.
         return f"<{self.id()} id=0x{id(self):0x}>"

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -86,6 +86,10 @@ class TestPlaceHolder(TestCase):
         test = PlaceHolder("test id", "description")
         self.assertEqual("description", test.shortDescription())
 
+    def test_testcase_is_hashable(self):
+        test = hash(self)
+        self.assertEqual(unittest.TestCase.__hash__(self), test)
+
     def test_repr_just_id(self):
         # repr(placeholder) shows you how the object was constructed.
         test = PlaceHolder("test id")


### PR DESCRIPTION
Defining a custom __eq__ method will prevent a TestCase instance from being hashed, and the django testing library attempts to hash all TestCases. 