### PR TITLE
Don't run Sphinx on Travis Python 3.3 target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,6 @@ install:
 
 script:
   - python -m testtools.run testtools.tests.test_suite
+  # Sphinx only supports 2.7 or >= 3.4
+  - if [ ${TRAVIS_PYTHON_VERSION} = "3.3" ]; then travis_terminate 0; fi
   - make clean-sphinx docs


### PR DESCRIPTION
Since Sphinx only supports 2.7 or >=3.4, we don't want to run it in
the 3.3 Travis target.