### PR TITLE
Don't add file without content

### DIFF
--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -832,7 +832,7 @@ class _StreamToTestRecord(StreamResult):
 
         case = case.got_timestamp(timestamp)
 
-        if file_name is not None:
+        if file_name is not None and file_bytes:
             case = case.got_file(file_name, file_bytes, mime_type)
 
         if test_tags is not None:

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -825,6 +825,18 @@ class TestStreamToDict(TestCase):
         self.assertEqual(["A", "B"], tests[0]['timestamps'])
         self.assertEqual(["C", None], tests[1]['timestamps'])
 
+    def test_files_skipped(self):
+        tests = []
+        result = StreamToDict(tests.append)
+        result.startTestRun()
+        result.status(file_name="some log.txt",
+            file_bytes="", eof=True,
+            mime_type="text/plain; charset=utf8", test_id="foo.bar")
+        result.stopTestRun()
+        self.assertThat(tests, HasLength(1))
+        details = tests[0]['details']
+        self.assertNotIn("some log.txt", details)
+
 
 class TestExtendedToStreamDecorator(TestCase):
 


### PR DESCRIPTION
In the test record API, skip adding file details to the record if there
are not bytes. This reduces that amount of data kept when there is none.