### PR TITLE
Python 3.6 invalid escape sequence deprecation fixes

### DIFF
--- a/testtools/content.py
+++ b/testtools/content.py
@@ -102,7 +102,7 @@ class Content(object):
         no charset parameter is present in the MIME type. (This is somewhat
         arbitrary, but consistent with RFC2617 3.7.1).
 
-        :raises ValueError: If the content type is not text/\*.
+        :raises ValueError: If the content type is not text/\\*.
         """
         if self.content_type.type != "text":
             raise ValueError("Not a text type %r" % self.content_type)

--- a/testtools/matchers/_warnings.py
+++ b/testtools/matchers/_warnings.py
@@ -21,7 +21,7 @@ from ._impl import Mismatch
 
 def WarningMessage(category_type, message=None, filename=None, lineno=None,
                    line=None):
-    """
+    r"""
     Create a matcher that will match `warnings.WarningMessage`\s.
 
     For example, to match captured `DeprecationWarning`\s with a message about

--- a/testtools/tests/matchers/test_basic.py
+++ b/testtools/tests/matchers/test_basic.py
@@ -395,7 +395,7 @@ class TestMatchesRegex(TestCase, TestMatchersInterface):
 
     describe_examples = [
         ("'c' does not match /a|b/", 'c', MatchesRegex('a|b')),
-        ("'c' does not match /a\d/", 'c', MatchesRegex(r'a\d')),
+        ("'c' does not match /a\\d/", 'c', MatchesRegex(r'a\d')),
         ("%r does not match /\\s+\\xa7/" % (_b('c'),),
             _b('c'), MatchesRegex(_b("\\s+\xA7"))),
         ("%r does not match /\\s+\\xa7/" % (_u('c'),),

--- a/testtools/tests/matchers/test_datastructures.py
+++ b/testtools/tests/matchers/test_datastructures.py
@@ -150,27 +150,27 @@ class TestMatchesSetwise(TestCase):
         self.assertMismatchWithDescriptionMatching(
             [3], MatchesSetwise(Equals(1), Equals(2), Equals(3)),
             MatchesRegex(
-                'There were 2 matchers left over: Equals\([12]\), '
-                'Equals\([12]\)'))
+                r'There were 2 matchers left over: Equals\([12]\), '
+                r'Equals\([12]\)'))
 
     def test_two_too_many_values(self):
         self.assertMismatchWithDescriptionMatching(
             [1, 2, 3, 4], MatchesSetwise(Equals(1), Equals(2)),
             MatchesRegex(
-                'There were 2 values left over: \[[34], [34]\]'))
+                r'There were 2 values left over: \[[34], [34]\]'))
 
     def test_mismatch_and_too_many_matchers(self):
         self.assertMismatchWithDescriptionMatching(
             [2, 3], MatchesSetwise(Equals(0), Equals(1), Equals(2)),
             MatchesRegex(
-                '.*There was 1 mismatch and 1 extra matcher: Equals\([01]\)',
+                r'.*There was 1 mismatch and 1 extra matcher: Equals\([01]\)',
                 re.S))
 
     def test_mismatch_and_too_many_values(self):
         self.assertMismatchWithDescriptionMatching(
             [2, 3, 4], MatchesSetwise(Equals(1), Equals(2)),
             MatchesRegex(
-                '.*There was 1 mismatch and 1 extra value: \[[34]\]',
+                r'.*There was 1 mismatch and 1 extra value: \[[34]\]',
                 re.S))
 
     def test_mismatch_and_two_too_many_matchers(self):
@@ -179,13 +179,13 @@ class TestMatchesSetwise(TestCase):
                 Equals(0), Equals(1), Equals(2), Equals(3)),
             MatchesRegex(
                 '.*There was 1 mismatch and 2 extra matchers: '
-                'Equals\([012]\), Equals\([012]\)', re.S))
+                r'Equals\([012]\), Equals\([012]\)', re.S))
 
     def test_mismatch_and_two_too_many_values(self):
         self.assertMismatchWithDescriptionMatching(
             [2, 3, 4, 5], MatchesSetwise(Equals(1), Equals(2)),
             MatchesRegex(
-                '.*There was 1 mismatch and 2 extra values: \[[145], [145]\]',
+                r'.*There was 1 mismatch and 2 extra values: \[[145], [145]\]',
                 re.S))
 
 

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -389,14 +389,14 @@ class TestAssertions(TestCase):
     def test_assertRaisesRegexp(self):
         # assertRaisesRegexp asserts that function raises particular exception
         # with particular message.
-        self.assertRaisesRegexp(RuntimeError, "M\w*e", self.raiseError,
+        self.assertRaisesRegexp(RuntimeError, r"M\w*e", self.raiseError,
                                 RuntimeError, "Message")
 
     def test_assertRaisesRegexp_wrong_error_type(self):
         # If function raises an exception of unexpected type,
         # assertRaisesRegexp re-raises it.
         self.assertRaises(ValueError, self.assertRaisesRegexp, RuntimeError,
-                          "M\w*e", self.raiseError, ValueError, "Message")
+                          r"M\w*e", self.raiseError, ValueError, "Message")
 
     def test_assertRaisesRegexp_wrong_message(self):
         # If function raises an exception with unexpected message


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.6.html#deprecated-python-behavior