### PR TITLE
Remove old Python 2.6 code

### DIFF
--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -15,7 +15,7 @@ Coding style
 In general, follow `PEP 8`_ except where consistency with the standard
 library's unittest_ module would suggest otherwise.
 
-testtools currently supports Python 2.6 and later, including Python 3.
+testtools currently supports Python 2.7 and Python 3.3 and later.
 
 Copyright assignment
 --------------------
@@ -144,7 +144,7 @@ including conformance with this HACKING file.
 
 Changes which all users should be made aware of should be documented in NEWS.
 
-We are now in full backwards compatibility mode - no more releases < 1.0.0, and 
+We are now in full backwards compatibility mode - no more releases < 1.0.0, and
 breaking compatibility will require consensus on the testtools-dev mailing list.
 Exactly what constitutes a backwards incompatible change is vague, but coarsely:
 

--- a/scripts/all-pythons
+++ b/scripts/all-pythons
@@ -89,5 +89,5 @@ def now():
 if __name__ == '__main__':
     sys.path.append(ROOT)
     result = TestProtocolClient(sys.stdout)
-    for version in '2.6 2.7 3.0 3.1 3.2'.split():
+    for version in '2.7 3.3 3.4 3.5 3.6'.split():
         run_for_python(version, result, sys.argv[1:])

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1095,7 +1095,6 @@ class TestExpectedFailure(TestWithDetails):
         self.assertDetailsProvided(case, "addUnexpectedSuccess",
             ["foo", "reason"])
 
-    @skipIf(not hasattr(unittest, 'expectedFailure'), 'Need py27+')
     def test_unittest_expectedFailure_decorator_works_with_failure(self):
         class ReferenceTest(TestCase):
             @unittest.expectedFailure
@@ -1106,7 +1105,6 @@ class TestExpectedFailure(TestWithDetails):
         result = test.run()
         self.assertEqual(True, result.wasSuccessful())
 
-    @skipIf(not hasattr(unittest, 'expectedFailure'), 'Need py27+')
     def test_unittest_expectedFailure_decorator_works_with_success(self):
         class ReferenceTest(TestCase):
             @unittest.expectedFailure
@@ -1450,12 +1448,6 @@ class TestRunTwiceNondeterministic(TestCase):
             second_result._events, self.expected_second_result)
 
 
-require_py27_minimum = skipIf(
-    sys.version < '2.7',
-    "Requires python 2.7 or greater"
-)
-
-
 class TestSkipping(TestCase):
     """Tests for skipping of tests functionality."""
 
@@ -1635,7 +1627,6 @@ class TestSkipping(TestCase):
             reason
         )
 
-    @require_py27_minimum
     def test_unittest_skip_decorator_does_not_run_setUp(self):
         reason = self.getUniqueString()
         self.check_skip_decorator_does_not_run_setup(
@@ -1643,7 +1634,6 @@ class TestSkipping(TestCase):
             reason
         )
 
-    @require_py27_minimum
     def test_unittest_skipIf_decorator_does_not_run_setUp(self):
         reason = self.getUniqueString()
         self.check_skip_decorator_does_not_run_setup(
@@ -1651,7 +1641,6 @@ class TestSkipping(TestCase):
             reason
         )
 
-    @require_py27_minimum
     def test_unittest_skipUnless_decorator_does_not_run_setUp(self):
         reason = self.getUniqueString()
         self.check_skip_decorator_does_not_run_setup(

--- a/testtools/testsuite.py
+++ b/testtools/testsuite.py
@@ -10,6 +10,7 @@ __all__ = [
     'sorted_tests',
 ]
 
+from collections import Counter
 from pprint import pformat
 import sys
 import threading
@@ -301,21 +302,11 @@ def filter_by_ids(suite_or_case, test_ids):
     return suite_or_case
 
 
-# XXX: Python 2.6. Replace this with Counter when we drop 2.6 support.
-def _counter(xs):
-    """Return a dict mapping values of xs to number of times they appear."""
-    counts = {}
-    for x in xs:
-        times = counts.setdefault(x, 0)
-        counts[x] = times + 1
-    return counts
-
-
 def sorted_tests(suite_or_case, unpack_outer=False):
     """Sort suite_or_case while preserving non-vanilla TestSuites."""
     # Duplicate test id can induce TypeError in Python 3.3.
     # Detect the duplicate test ids, raise exception when found.
-    seen = _counter(case.id() for case in iterate_tests(suite_or_case))
+    seen = Counter(case.id() for case in iterate_tests(suite_or_case))
     duplicates = dict(
         (test_id, count) for test_id, count in seen.items() if count > 1)
     if duplicates:


### PR DESCRIPTION
Support for Python 2.6 and 3.2 was dropped in https://github.com/testing-cabal/testtools/pull/198, but tests and docs for the time being. 

This removes some of the old code for Python 2.6 (and a bit of docs).