### PR TITLE
Drop support for EOL Python 3.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ testtools.egg-info
 /.eggs/
 AUTHORS
 ChangeLog
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -15,6 +14,4 @@ install:
 
 script:
   - python -m testtools.run testtools.tests.test_suite
-  # Sphinx only supports 2.7 or >= 3.4
-  - if [ ${TRAVIS_PYTHON_VERSION} = "3.3" ]; then travis_terminate 0; fi
   - make clean-sphinx docs

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ under the same license as Python, see LICENSE for details.
 Supported platforms
 -------------------
 
- * Python 2.7+ or 3.3+ / pypy (2.x+)
+ * Python 2.7 or 3.4+ / pypy (2.x+)
 
 If you would like to use testtools for earlier Pythons, please use testtools
 1.9.0, or for *really* old Pythons, testtools 0.9.15.
@@ -46,7 +46,7 @@ Optional Dependencies
 If you would like to use our Twisted support, then you will need Twisted.
 
 If you want to use ``fixtures`` then you can either install fixtures (e.g. from
-https://launchpad.net/python-fixtures or http://pypi.python.org/pypi/fixtures)
+https://launchpad.net/python-fixtures or https://pypi.python.org/pypi/fixtures)
 or alternatively just make sure your fixture objects obey the same protocol.
 
 
@@ -54,7 +54,7 @@ Bug reports and patches
 -----------------------
 
 Please report bugs using Launchpad at <https://bugs.launchpad.net/testtools>.
-Patches should be submitted as Github pull requests, or mailed to the authors.
+Patches should be submitted as GitHub pull requests, or mailed to the authors.
 See ``doc/hacking.rst`` for more details.
 
 There's no mailing list for this project yet, however the testing-in-python

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -15,7 +15,7 @@ Coding style
 In general, follow `PEP 8`_ except where consistency with the standard
 library's unittest_ module would suggest otherwise.
 
-testtools currently supports Python 2.7 and Python 3.3 and later.
+testtools currently supports Python 2.7 and Python 3.4 and later.
 
 Copyright assignment
 --------------------

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -92,10 +92,12 @@ Cross-Python compatibility
 --------------------------
 
 testtools gives you the very latest in unit testing technology in a way that
-will work with Python 2.7, 3.3, 3.4, 3.5, and pypy.
+will work with Python 2.7, 3.4+, and pypy.
 
 If you wish to use testtools with Python 2.4 or 2.5, then please use testtools
 0.9.15.
 
 If you wish to use testtools with Python 2.6 or 3.2, then please use testtools
 1.9.0.
+
+If you wish to use testtools with Python 3.3, then please use testtools 2.3.0.

--- a/scripts/all-pythons
+++ b/scripts/all-pythons
@@ -89,5 +89,5 @@ def now():
 if __name__ == '__main__':
     sys.path.append(ROOT)
     result = TestProtocolClient(sys.stdout)
-    for version in '2.7 3.3 3.4 3.5 3.6'.split():
+    for version in '2.7 3.4 3.5 3.6'.split():
         run_for_python(version, result, sys.argv[1:])

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ except:
 
 
 setuptools.setup(
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     cmdclass=cmd_class,
     setup_requires=['pbr'],
     pbr=True)

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -2599,7 +2599,7 @@ class TestNonAsciiResults(TestCase):
         self.assertIn(self._as_output(_u("\uFFFD\uFFFD\uFFFD")), textoutput)
 
     def _local_os_error_matcher(self):
-        if sys.version_info > (3, 3):
+        if sys.version_info > (3, 4):
             return MatchesAny(Contains("FileExistsError: "),
                               Contains("PermissionError: "))
         elif os.name != "nt":


### PR DESCRIPTION
Also add `python_requires` to setup to help pip.

eg. https://stackoverflow.com/q/44660448/724176