### PR TITLE
Allow skip/skipIf/skipUnless as class decorators

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,16 @@ testtools NEWS
 
 Changes and improvements to testtools_, grouped by release.
 
+NEXT
+~~~~
+
+Improvements
+------------
+
+* The skip, skipIf, and skipUnless decorators can now be used as class
+  decorators as well as test method decorators, just as they can in
+  unittest.
+
 2.3.0
 ~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -93,3 +93,4 @@ Thanks
  * ClusterHQ Ltd
  * Tristan Seligmann
  * Jonathan Jacobs
+ * Zane Bitter

--- a/testtools/runtest.py
+++ b/testtools/runtest.py
@@ -124,10 +124,12 @@ class RunTest(object):
     def _run_core(self):
         """Run the user supplied test code."""
         test_method = self.case._get_test_method()
-        if getattr(test_method, '__unittest_skip__', False):
+        skip_case = getattr(self.case, '__unittest_skip__', False)
+        if skip_case or getattr(test_method, '__unittest_skip__', False):
             self.result.addSkip(
                 self.case,
-                reason=getattr(test_method, '__unittest_skip_why__', None)
+                reason=getattr(self.case if skip_case else test_method,
+                               '__unittest_skip_why__', None)
             )
             return
 

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -60,8 +60,6 @@ from testtools.testresult import (
     TestResult,
     )
 
-wraps = try_import('functools.wraps')
-
 
 class TestSkipped(Exception):
     """Raised within TestCase.run() when a test is skipped."""
@@ -950,20 +948,18 @@ def skip(reason):
     @unittest.skip decorator.
     """
     def decorator(test_item):
+        @functools.wraps(test_item)
+        def skip_wrapper(*args, **kwargs):
+            raise TestCase.skipException(reason)
+        test_item = skip_wrapper
+
         # This attribute signals to RunTest._run_core that the entire test
         # must be skipped - including setUp and tearDown. This makes us
         # compatible with testtools.skip* functions, which set the same
         # attributes.
         test_item.__unittest_skip__ = True
         test_item.__unittest_skip_why__ = reason
-        if wraps is not None:
-            @wraps(test_item)
-            def skip_wrapper(*args, **kwargs):
-                raise TestCase.skipException(reason)
-        else:
-            def skip_wrapper(test_item):
-                test_item.skip(reason)
-        return skip_wrapper
+        return test_item
     return decorator
 
 

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1586,6 +1586,28 @@ class TestSkipping(TestCase):
         test.run(result)
         self.assertEqual('addSuccess', events[1][0])
 
+    def test_skip_decorator_shared(self):
+        def shared(testcase):
+            testcase.fail('nope')
+
+        class SkippingTest(TestCase):
+            test_skip = skipIf(True, "skipping this test")(shared)
+
+        class NotSkippingTest(TestCase):
+            test_no_skip = skipIf(False, "skipping this test")(shared)
+
+        events = []
+        result = Python26TestResult(events)
+        test = SkippingTest("test_skip")
+        test.run(result)
+        self.assertEqual('addSuccess', events[1][0])
+
+        events2 = []
+        result2 = Python26TestResult(events2)
+        test2 = NotSkippingTest("test_no_skip")
+        test2.run(result2)
+        self.assertEqual('addFailure', events2[1][0])
+
     def check_skip_decorator_does_not_run_setup(self, decorator, reason):
         class SkippingTest(TestCase):
 

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -43,6 +43,7 @@ from testtools.testcase import (
     attr,
     Nullary,
     WithAttributes,
+    TestSkipped,
     )
 from testtools.testresult.doubles import (
     Python26TestResult,
@@ -1608,6 +1609,48 @@ class TestSkipping(TestCase):
         test2.run(result2)
         self.assertEqual('addFailure', events2[1][0])
 
+    def test_skip_class_decorator(self):
+        @skip("skipping this testcase")
+        class SkippingTest(TestCase):
+            def test_that_is_decorated_with_skip(self):
+                self.fail()
+        events = []
+        result = Python26TestResult(events)
+        try:
+            test = SkippingTest("test_that_is_decorated_with_skip")
+        except TestSkipped:
+            self.fail('TestSkipped raised')
+        test.run(result)
+        self.assertEqual('addSuccess', events[1][0])
+
+    def test_skipIf_class_decorator(self):
+        @skipIf(True, "skipping this testcase")
+        class SkippingTest(TestCase):
+            def test_that_is_decorated_with_skipIf(self):
+                self.fail()
+        events = []
+        result = Python26TestResult(events)
+        try:
+            test = SkippingTest("test_that_is_decorated_with_skipIf")
+        except TestSkipped:
+            self.fail('TestSkipped raised')
+        test.run(result)
+        self.assertEqual('addSuccess', events[1][0])
+
+    def test_skipUnless_class_decorator(self):
+        @skipUnless(False, "skipping this testcase")
+        class SkippingTest(TestCase):
+            def test_that_is_decorated_with_skipUnless(self):
+                self.fail()
+        events = []
+        result = Python26TestResult(events)
+        try:
+            test = SkippingTest("test_that_is_decorated_with_skipUnless")
+        except TestSkipped:
+            self.fail('TestSkipped raised')
+        test.run(result)
+        self.assertEqual('addSuccess', events[1][0])
+
     def check_skip_decorator_does_not_run_setup(self, decorator, reason):
         class SkippingTest(TestCase):
 
@@ -1623,6 +1666,28 @@ class TestSkipping(TestCase):
                 self.fail()
 
         test = SkippingTest('test_skipped')
+        self.check_test_does_not_run_setup(test, reason)
+
+        # Use the decorator passed to us:
+        @decorator
+        class SkippingTestCase(TestCase):
+
+            setup_ran = False
+
+            def setUp(self):
+                super(SkippingTestCase, self).setUp()
+                self.setup_ran = True
+
+            def test_skipped(self):
+                self.fail()
+
+        try:
+            test = SkippingTestCase('test_skipped')
+        except TestSkipped:
+            self.fail('TestSkipped raised')
+        self.check_test_does_not_run_setup(test, reason)
+
+    def check_test_does_not_run_setup(self, test, reason):
         result = test.run()
         self.assertTrue(result.wasSuccessful())
         self.assertTrue(reason in result.skip_reasons, result.skip_reasons)


### PR DESCRIPTION
In unittest/unittest2 the skip/skipIf/skipUnless decorators can be used to
decorate either individual test methods or entire TestCase classes.
However, the testtools equivalents could previously only be used to
decorate test methods. If used on a TestCase the class would be replaced
with a function, resulting in the tests either not be discovered at all or
(if a custom test loader was used) potentially an error.

This change allows the skip decorators to be used on the TestCase subclass,
for equivalent functionality with unittest.

Fixes #205 