### PR TITLE
Don't install Sphinx on Travis Python 3.3 target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ python:
 
 install:
   - pip install -U pip wheel setuptools
-  - pip install sphinx Twisted
+  - if [ ${TRAVIS_PYTHON_VERSION} != "3.3" ]; then pip install sphinx; fi
+  - pip install Twisted
   - pip install .[test]
 
 script:


### PR DESCRIPTION
Sphinx doesn't support Python 3.3, and we already don't run Sphinx in the
Travis Python 3.3 target. However, it fails to install because there is no
longer any Sphinx package available for Python 3.3. So avoid even trying to
install it.