### PR TITLE
PyCharm IDE unittest detection compatibility fix

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -25,10 +25,14 @@ import warnings
 from extras import (
     safe_hasattr,
     try_import,
-    try_imports,
     )
 # To let setup.py work, make this a conditional import.
-unittest = try_imports(['unittest2', 'unittest'])
+# Don't use extras.try_imports, as it interferes with PyCharm's unittest
+# detection algorithm. See: https://youtrack.jetbrains.com/issue/PY-26630
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import six
 
 from testtools import (


### PR DESCRIPTION
PyCharm is a Python IDE developed by JetBrains. It uses some algorithm
to detect classes that are derived from unittest.TestCase, and the
dynamic import that is used prior to this patch causes it to
malfunction. It fails to detect tests that are derived from
testtools.TestCase as unittests for the purposes of their runner.
Doing the conditional imports in a more standard Pythonic way, we can
allow testtools to be more compatible with their approach.

I believe that it should not necessarily be the responsibility of every
library author/maintainer to go out of their way to adjust to the
(flawed/limited) functions of various IDEs/toolchains, but in this case
I think the change is minimal and Pythonic, and the benefit is
significant for those who use this fairly popular IDE.

For the original bug on their tracker, see:
https://youtrack.jetbrains.com/issue/PY-26630