### PR TITLE
Drop support for EOL Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7-dev"

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ under the same license as Python, see LICENSE for details.
 Supported platforms
 -------------------
 
- * Python 2.7 or 3.4+ / pypy (2.x+)
+ * Python 2.7 or 3.5+ / pypy (2.x+)
 
 If you would like to use testtools for earlier Pythons, please use testtools
 1.9.0, or for *really* old Pythons, testtools 0.9.15.

--- a/doc/hacking.rst
+++ b/doc/hacking.rst
@@ -15,7 +15,7 @@ Coding style
 In general, follow `PEP 8`_ except where consistency with the standard
 library's unittest_ module would suggest otherwise.
 
-testtools currently supports Python 2.7 and Python 3.4 and later.
+testtools currently supports Python 2.7 and Python 3.5 and later.
 
 Copyright assignment
 --------------------

--- a/scripts/all-pythons
+++ b/scripts/all-pythons
@@ -89,5 +89,5 @@ def now():
 if __name__ == '__main__':
     sys.path.append(ROOT)
     result = TestProtocolClient(sys.stdout)
-    for version in '2.7 3.4 3.5 3.6'.split():
+    for version in '2.7 3.5 3.6'.split():
         run_for_python(version, result, sys.argv[1:])

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.4
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: Implementation :: CPython

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except:
 
 
 setuptools.setup(
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
     cmdclass=cmd_class,
     setup_requires=['pbr'],
     pbr=True)


### PR DESCRIPTION
Fixes #279.

Python 3.4 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.7 | 2010-07-03 | 2020-01-01
3.4 | 2014-03-16 | 2019-03-16

Source: https://en.wikipedia.org/wiki/CPython#Version_history

Further, the 3.4 job fails on the CI because Twisted no longer supports it:

```console
$ pip install sphinx Twisted
DEPRECATION: Python 3.4 support has been deprecated. pip 19.1 will be the last one supporting it. Please upgrade your Python as Python 3.4 won't be maintained after March 2019 (cf PEP 429).
Collecting sphinx
  Downloading https://files.pythonhosted.org/packages/7d/66/a4af242b4348b729b9d46ce5db23943ce9bca7da9bbe2ece60dc27f26420/Sphinx-1.8.5-py2.py3-none-any.whl (3.1MB)
Collecting Twisted
  Downloading https://files.pythonhosted.org/packages/0b/95/5fff90cd4093c79759d736e5f7c921c8eb7e5057a70d753cdb4e8e5895d7/Twisted-19.10.0.tar.bz2 (3.1MB)
    ERROR: Complete output from command python setup.py egg_info:
    ERROR: Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-l2cpxb2_/Twisted/setup.py", line 20, in <module>
        setuptools.setup(**_setup["getSetupArgs"]())
      File "<string>", line 258, in getSetupArgs
      File "<string>", line 209, in _checkPythonVersion
    ImportError: Twisted on Python 3 requires Python 3.5 or later.
    ----------------------------------------
ERROR: Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-l2cpxb2_/Twisted/
The command "pip install sphinx Twisted" failed and exited with 1 during .
```
