### PR TITLE
Remove unitest2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,5 @@ fixtures>=1.3.0
 # 'mimeparse' has not been uploaded by the maintainer with Python3 compat
 # but someone kindly uploaded a fixed version as 'python-mimeparse'.
 python-mimeparse
-unittest2>=1.0.0
 traceback2
 six>=1.4.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ home-page = https://github.com/testing-cabal/testtools
 description-file = doc/overview.rst
 author = Jonathan M. Lange
 author-email = jml+testtools@mumak.net
-classifier = 
+classifier =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License
@@ -28,7 +28,6 @@ classifier =
 test =
   testscenarios
   testresources
-  unittest2>=1.1.0
 
 [files]
 packages = testtools

--- a/testtools/run.py
+++ b/testtools/run.py
@@ -12,10 +12,9 @@ import argparse
 from functools import partial
 import os.path
 import sys
+import unittest
 
 from extras import safe_hasattr, try_imports
-# To let setup.py work, make this a conditional import.
-unittest = try_imports(['unittest2', 'unittest'])
 
 from testtools import TextTestResult, testcase
 from testtools.compat import classtypes, istext, unicode_output_stream
@@ -50,7 +49,7 @@ def list_test(test):
         describing things that failed to import.
     """
     unittest_import_strs = set([
-        'unittest2.loader.ModuleImportFailure.',
+        'unittest.loader.ModuleImportFailure.',
         'unittest.loader.ModuleImportFailure.',
         'discover.ModuleImportFailure.'
         ])

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -20,19 +20,14 @@ import copy
 import functools
 import itertools
 import sys
+import unittest
 import warnings
 
 from extras import (
     safe_hasattr,
     try_import,
     )
-# To let setup.py work, make this a conditional import.
-# Don't use extras.try_imports, as it interferes with PyCharm's unittest
-# detection algorithm. See: https://youtrack.jetbrains.com/issue/PY-26630
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+
 import six
 
 from testtools import (
@@ -70,7 +65,7 @@ wraps = try_import('functools.wraps')
 class TestSkipped(Exception):
     """Raised within TestCase.run() when a test is skipped."""
 TestSkipped = try_import('unittest.case.SkipTest', TestSkipped)
-TestSkipped = try_import('unittest2.case.SkipTest', TestSkipped)
+TestSkipped = try_import('unittest.case.SkipTest', TestSkipped)
 
 
 class _UnexpectedSuccess(Exception):
@@ -82,7 +77,7 @@ class _UnexpectedSuccess(Exception):
 _UnexpectedSuccess = try_import(
     'unittest.case._UnexpectedSuccess', _UnexpectedSuccess)
 _UnexpectedSuccess = try_import(
-    'unittest2.case._UnexpectedSuccess', _UnexpectedSuccess)
+    'unittest.case._UnexpectedSuccess', _UnexpectedSuccess)
 
 
 class _ExpectedFailure(Exception):
@@ -94,7 +89,7 @@ class _ExpectedFailure(Exception):
 _ExpectedFailure = try_import(
     'unittest.case._ExpectedFailure', _ExpectedFailure)
 _ExpectedFailure = try_import(
-    'unittest2.case._ExpectedFailure', _ExpectedFailure)
+    'unittest.case._ExpectedFailure', _ExpectedFailure)
 
 
 # Copied from unittest before python 3.4 release. Used to maintain

--- a/testtools/tests/test_run.py
+++ b/testtools/tests/test_run.py
@@ -3,14 +3,13 @@
 """Tests for the test runner logic."""
 
 import doctest
-from unittest import TestSuite
 import sys
 from textwrap import dedent
+import unittest
 
 from extras import try_import
 fixtures = try_import('fixtures')
 testresources = try_import('testresources')
-import unittest2
 
 import testtools
 from testtools import TestCase, run, skipUnless
@@ -195,13 +194,13 @@ testtools.runexample.TestFoo.test_quux
         broken = self.useFixture(SampleTestFixture(broken=True))
         out = StringIO()
         # XXX: http://bugs.python.org/issue22811
-        unittest2.defaultTestLoader._top_level_dir = None
+        unittest.defaultTestLoader._top_level_dir = None
         exc = self.assertRaises(
             SystemExit,
             run.main, ['prog', 'discover', '-l', broken.package.base, '*.py'], out)
         self.assertEqual(2, exc.args[0])
         self.assertThat(out.getvalue(), DocTestMatches("""\
-unittest2.loader._FailedTest.runexample
+unittest.loader._FailedTest.runexample
 Failed to import test module: runexample
 Traceback (most recent call last):
   File ".../loader.py", line ..., in _find_test_path
@@ -304,7 +303,7 @@ testtools.resourceexample.TestFoo.test_foo
                 self.fail('b')
         with fixtures.MonkeyPatch('sys.stdout', stdout.stream):
             runner = run.TestToolsTestRunner(failfast=True)
-            runner.run(TestSuite([Failing('test_a'), Failing('test_b')]))
+            runner.run(unittest.TestSuite([Failing('test_a'), Failing('test_b')]))
         self.assertThat(
             stdout.getDetails()['stdout'].as_text(), Contains('Ran 1 test'))
 
@@ -345,7 +344,7 @@ OK
         pkg = self.useFixture(SampleLoadTestsPackage())
         out = StringIO()
         # XXX: http://bugs.python.org/issue22811
-        unittest2.defaultTestLoader._top_level_dir = None
+        unittest.defaultTestLoader._top_level_dir = None
         self.assertEqual(None, run.main(
             ['prog', 'discover', '-l', pkg.package.base], out))
         self.assertEqual(dedent("""\

--- a/testtools/tests/test_testsuite.py
+++ b/testtools/tests/test_testsuite.py
@@ -5,7 +5,6 @@
 import doctest
 from pprint import pformat
 import unittest
-import unittest2
 
 from extras import try_import
 
@@ -223,9 +222,9 @@ TypeError: run() takes ...1 ...argument...2...given...
                 raise cls.skipException('foo')
             def test_notrun(self):
                 pass
-        # Test discovery uses the default suite from unittest2 (unless users
+        # Test discovery uses the default suite from unittest (unless users
         # deliberately change things, in which case they keep both pieces).
-        suite = unittest2.TestSuite([Skips("test_notrun")])
+        suite = unittest.TestSuite([Skips("test_notrun")])
         log = []
         result = LoggingResult(log)
         suite.run(result)
@@ -240,9 +239,9 @@ TypeError: run() takes ...1 ...argument...2...given...
                 super(Simples, cls).setUpClass()
             def test_simple(self):
                 pass
-        # Test discovery uses the default suite from unittest2 (unless users
+        # Test discovery uses the default suite from unittest (unless users
         # deliberately change things, in which case they keep both pieces).
-        suite = unittest2.TestSuite([Simples("test_simple")])
+        suite = unittest.TestSuite([Simples("test_simple")])
         log = []
         result = LoggingResult(log)
         suite.run(result)

--- a/testtools/tests/twistedsupport/test_deferred.py
+++ b/testtools/tests/twistedsupport/test_deferred.py
@@ -52,5 +52,5 @@ class TestExtractResult(NeedsTwistedTestCase):
 
 
 def test_suite():
-    from unittest2 import TestLoader, TestSuite
+    from unittest import TestLoader, TestSuite
     return TestLoader().loadTestsFromName(__name__)

--- a/testtools/tests/twistedsupport/test_matchers.py
+++ b/testtools/tests/twistedsupport/test_matchers.py
@@ -205,5 +205,5 @@ class FailureResultTests(NeedsTwistedTestCase):
 
 
 def test_suite():
-    from unittest2 import TestLoader, TestSuite
+    from unittest import TestLoader, TestSuite
     return TestLoader().loadTestsFromName(__name__)

--- a/testtools/tests/twistedsupport/test_runtest.py
+++ b/testtools/tests/twistedsupport/test_runtest.py
@@ -1016,7 +1016,7 @@ class TestCaptureTwistedLogs(NeedsTwistedTestCase):
 
 
 def test_suite():
-    from unittest2 import TestLoader, TestSuite
+    from unittest import TestLoader, TestSuite
     return TestLoader().loadTestsFromName(__name__)
 
 

--- a/testtools/testsuite.py
+++ b/testtools/testsuite.py
@@ -18,7 +18,6 @@ import unittest
 
 from extras import safe_hasattr, try_imports
 # This is just to let setup.py work, as testtools is imported in setup.py.
-unittest2 = try_imports(['unittest2', 'unittest'])
 Queue = try_imports(['Queue.Queue', 'queue.Queue'])
 
 import testtools
@@ -36,7 +35,7 @@ def iterate_tests(test_suite_or_case):
                 yield subtest
 
 
-class ConcurrentTestSuite(unittest2.TestSuite):
+class ConcurrentTestSuite(unittest.TestSuite):
     """A TestSuite whose run() calls out to a concurrency strategy."""
 
     def __init__(self, suite, make_tests, wrap_result=None):
@@ -199,7 +198,7 @@ class ConcurrentStreamTestSuite(object):
             process_result.stopTestRun()
 
 
-class FixtureSuite(unittest2.TestSuite):
+class FixtureSuite(unittest.TestSuite):
 
     def __init__(self, fixture, tests):
         super(FixtureSuite, self).__init__(tests)


### PR DESCRIPTION
unittest2 hasn't been updated since June 2015 and since Python 2.6 support was dropped, it is no longer needed.