### PR TITLE
Update docs about which version to use for Python 3.4

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,11 +33,12 @@ Supported platforms
 
  * Python 2.7 or 3.5+ / PyPy
 
-If you would like to use testtools for earlier Pythons, please use testtools
-1.9.0, or for *really* old Pythons, testtools 0.9.15.
+If you would like to use testtools for earlier Pythons, consult the compatibility docs:
+
+ * https://testtools.readthedocs.io/en/latest/overview.html#cross-python-compatibility
 
 testtools probably works on all OSes that Python works on, but is most heavily
-tested on Linux and OS X.
+tested on Linux and macOS.
 
 
 Optional Dependencies

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -100,4 +100,4 @@ If you wish to use testtools with Python 2.4 or 2.5, then please use testtools
 If you wish to use testtools with Python 2.6 or 3.2, then please use testtools
 1.9.0.
 
-If you wish to use testtools with Python 3.3, then please use testtools 2.3.0.
+If you wish to use testtools with Python 3.3 or 3.4, then please use testtools 2.3.0.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -92,7 +92,7 @@ Cross-Python compatibility
 --------------------------
 
 testtools gives you the very latest in unit testing technology in a way that
-will work with Python 2.7, 3.4+, and pypy.
+will work with Python 2.7, 3.5+, and PyPy.
 
 If you wish to use testtools with Python 2.4 or 2.5, then please use testtools
 0.9.15.


### PR DESCRIPTION
https://github.com/testing-cabal/testtools/pull/284 dropped support for EOL Python 3.4.

This PR documents it, in only one place to remove duplication, and refer to that one place from the other.