### PR TITLE
Drop traceback2 in favor of traceback and remove unused linecache2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ fixtures>=1.3.0
 # but someone kindly uploaded a fixed version as 'python-mimeparse'.
 python-mimeparse
 unittest2>=1.0.0
-traceback2

--- a/testtools/compat.py
+++ b/testtools/compat.py
@@ -17,11 +17,6 @@ import os
 import sys
 import unicodedata
 
-from extras import try_import
-
-# To let setup.py work, make this a conditional import.
-linecache = try_import('linecache2')
-
 
 def reraise(exc_class, exc_obj, exc_tb, _marker=object()):
     """Re-raise an exception received from sys.exc_info() or similar."""

--- a/testtools/content.py
+++ b/testtools/content.py
@@ -15,10 +15,9 @@ __all__ = [
 import codecs
 import json
 import os
+import traceback
 
 from extras import try_import
-# To let setup.py work, make this a conditional import.
-traceback = try_import('traceback2')
 
 from testtools.compat import (
     _b,


### PR DESCRIPTION
I notice that my subunit logs contains confusing `Traceback (most recent call last):` line even if there is no traceback at all. The issue originates from a CPython regression fixed in CPython 3.5 [1]. traceback2 backported that fix but there is no new release since then [2]. As testtools already requires Python 3.5+, I propose to move away from traceback2 instead of putting more efforts to traceback2.

This might depend on the removal of unittest2 (https://github.com/testing-cabal/testtools/pull/277 or https://github.com/testing-cabal/testtools/pull/295) as there is some coupling among unittest2/traceback2/linecache2 [3].

[1] https://github.com/python/cpython/commit/c3f417dc47b3a9564608c98cd176c530d9ebdf09
[2] https://github.com/testing-cabal/traceback2/commit/2218e9cf14069d804da2f50db8e85fc6648638f3
[3] https://github.com/testing-cabal/traceback2/issues/10#issuecomment-273920946