### PR TITLE
Update github actions config to use release 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, pypy3]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
         os: [ubuntu-18.04]
-        include:
-          # Dev versions
-          - { python-version: 3.9-dev, os: ubuntu-20.04 }
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.9 was released last month so we no longer need to rely on a dev
build of it. This commit updates the github actions config to use
released python 3.9 instead of the dev version.