### PR TITLE
Reduce dependencies

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,11 @@ Changes
   moved to the ``extras`` package. It is no longer useless on Python 3-only
   projects.
 
+* The ``try_imports`` utility has been removed from ``testtools.helpers``.
+  This was a compat wrapper introduced in 0.9.25 when the utility itself was
+  moved to the ``extras`` package. It is no longer used within testtools and
+  has therefore been dropped.
+
 2.4.0
 ~~~~~
 

--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,7 @@ NEXT
 
 Improvements
 ------------
+
 * The skip, skipIf, and skipUnless decorators can now be used as class
   decorators as well as test method decorators, just as they can in
   unittest.
@@ -18,6 +19,11 @@ Changes
 * The dependency on the ``unittest2`` module has been removed. This has some
   knock on effects, including the removal of the ``assertItemsEqual`` helper
   which was removed from ``unittest`` in Python 3.x.
+
+* The ``safe_hasattr`` utility has been removed from ``testtools.helpers``.
+  This was a compat wrapper introduced in 0.9.25 when the utility itself was
+  moved to the ``extras`` package. It is no longer useless on Python 3-only
+  projects.
 
 2.4.0
 ~~~~~

--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,13 @@ Improvements
   decorators as well as test method decorators, just as they can in
   unittest.
 
+Changes
+-------
+
+* The dependency on the ``unittest2`` module has been removed. This has some
+  knock on effects, including the removal of the ``assertItemsEqual`` helper
+  which was removed from ``unittest`` in Python 3.x.
+
 2.4.0
 ~~~~~
 

--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -1449,18 +1449,6 @@ You can do::
    defer = try_import('twisted.internet.defer')
 
 
-Instead of::
-
-  try:
-      from StringIO import StringIO
-  except ImportError:
-      from io import StringIO
-
-You can do::
-
-  StringIO = try_imports(['StringIO.StringIO', 'io.StringIO'])
-
-
 Nullary callables
 -----------------
 

--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -1431,24 +1431,6 @@ id and can be used when filtering tests by id. (e.g. via ``--load-list``)::
 General helpers
 ===============
 
-Conditional imports
--------------------
-
-Lots of the time we would like to conditionally import modules.  testtools
-uses the small library extras to do this. This used to be part of testtools.
-
-Instead of::
-
-  try:
-      from twisted.internet import defer
-  except ImportError:
-      defer = None
-
-You can do::
-
-   defer = try_import('twisted.internet.defer')
-
-
 Nullary callables
 -----------------
 

--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -1461,14 +1461,6 @@ You can do::
   StringIO = try_imports(['StringIO.StringIO', 'io.StringIO'])
 
 
-Safe attribute testing
-----------------------
-
-``hasattr`` is broken_ on many versions of Python. The helper ``safe_hasattr``
-can be used to safely test whether an object has a particular attribute. Like
-``try_import`` this used to be in testtools but is now in extras.
-
-
 Nullary callables
 -----------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,3 @@ pbr>=0.11
 # or explicitly specifies the dependency
 extras>=1.0.0
 fixtures>=1.3.0
-# 'mimeparse' has not been uploaded by the maintainer with Python3 compat
-# but someone kindly uploaded a fixed version as 'python-mimeparse'.
-python-mimeparse

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 pbr>=0.11
+# TODO(stephenfin): Remove this once fixtures no longer depends on extras
+# or explicitly specifies the dependency
 extras>=1.0.0
 fixtures>=1.3.0
 # 'mimeparse' has not been uploaded by the maintainer with Python3 compat

--- a/testtools/__init__.py
+++ b/testtools/__init__.py
@@ -45,70 +45,58 @@ __all__ = [
     'unique_text_generator',
     ]
 
-# Compat - removal announced in 0.9.25.
-try:
-    from testtools.helpers import try_import
-except ImportError:
-    # Support reading __init__ for __version__ without extras, because pip does
-    # not support setup_requires.
-    pass
-else:
-
-    from testtools.matchers._impl import (
-        Matcher,
-        )
+from testtools.helpers import try_import
+from testtools.matchers._impl import Matcher
 # Shut up, pyflakes. We are importing for documentation, not for namespacing.
-    Matcher
+Matcher
 
-    from testtools.runtest import (
-        MultipleExceptions,
-        RunTest,
-        )
-    from testtools.testcase import (
-        DecorateTestCaseResult,
-        ErrorHolder,
-        ExpectedException,
-        PlaceHolder,
-        TestCase,
-        clone_test_with_new_id,
-        run_test_with,
-        skip,
-        skipIf,
-        skipUnless,
-        unique_text_generator,
-        )
-    from testtools.testresult import (
-        CopyStreamResult,
-        ExtendedToOriginalDecorator,
-        ExtendedToStreamDecorator,
-        MultiTestResult,
-        ResourcedToStreamDecorator,
-        StreamFailFast,
-        StreamResult,
-        StreamResultRouter,
-        StreamSummary,
-        StreamTagger,
-        StreamToDict,
-        StreamToExtendedDecorator,
-        StreamToQueue,
-        Tagger,
-        TestByTestResult,
-        TestControl,
-        TestResult,
-        TestResultDecorator,
-        TextTestResult,
-        ThreadsafeForwardingResult,
-        TimestampingStreamResult,
-        )
-    from testtools.testsuite import (
-        ConcurrentTestSuite,
-        ConcurrentStreamTestSuite,
-        FixtureSuite,
-        iterate_tests,
-        )
-    from testtools.distutilscmd import (
-        TestCommand,
-        )
+from testtools.runtest import (
+    MultipleExceptions,
+    RunTest,
+)
+from testtools.testcase import (
+    DecorateTestCaseResult,
+    ErrorHolder,
+    ExpectedException,
+    PlaceHolder,
+    TestCase,
+    clone_test_with_new_id,
+    run_test_with,
+    skip,
+    skipIf,
+    skipUnless,
+    unique_text_generator,
+)
+from testtools.testresult import (
+    CopyStreamResult,
+    ExtendedToOriginalDecorator,
+    ExtendedToStreamDecorator,
+    MultiTestResult,
+    ResourcedToStreamDecorator,
+    StreamFailFast,
+    StreamResult,
+    StreamResultRouter,
+    StreamSummary,
+    StreamTagger,
+    StreamToDict,
+    StreamToExtendedDecorator,
+    StreamToQueue,
+    Tagger,
+    TestByTestResult,
+    TestControl,
+    TestResult,
+    TestResultDecorator,
+    TextTestResult,
+    ThreadsafeForwardingResult,
+    TimestampingStreamResult,
+)
+from testtools.testsuite import (
+    ConcurrentTestSuite,
+    ConcurrentStreamTestSuite,
+    FixtureSuite,
+    iterate_tests,
+)
+from testtools.distutilscmd import TestCommand
 
 # same format as sys.version_info: "A tuple containing the five components of
 # the version number: major, minor, micro, releaselevel, and serial. All

--- a/testtools/__init__.py
+++ b/testtools/__init__.py
@@ -47,7 +47,7 @@ __all__ = [
 
 # Compat - removal announced in 0.9.25.
 try:
-    from extras import try_import
+    from testtools.helpers import try_import
 except ImportError:
     # Support reading __init__ for __version__ without extras, because pip does
     # not support setup_requires.

--- a/testtools/__init__.py
+++ b/testtools/__init__.py
@@ -42,16 +42,12 @@ __all__ = [
     'ThreadsafeForwardingResult',
     'TimestampingStreamResult',
     'try_import',
-    'try_imports',
     'unique_text_generator',
     ]
 
 # Compat - removal announced in 0.9.25.
 try:
-    from extras import (
-        try_import,
-        try_imports,
-        )
+    from extras import try_import
 except ImportError:
     # Support reading __init__ for __version__ without extras, because pip does
     # not support setup_requires.

--- a/testtools/content.py
+++ b/testtools/content.py
@@ -13,19 +13,14 @@ __all__ = [
     ]
 
 import codecs
+import functools
 import json
 import os
 import traceback
 
-from extras import try_import
-
-from testtools.compat import (
-    _b,
-)
+from testtools.compat import _b
 from testtools.content_type import ContentType, JSON, UTF8_TEXT
 
-
-functools = try_import('functools')
 
 _join_b = _b("").join
 

--- a/testtools/helpers.py
+++ b/testtools/helpers.py
@@ -2,15 +2,11 @@
 
 __all__ = [
     'try_import',
-    'try_imports',
 ]
 
 import sys
 
-from extras import (
-    try_import,
-    try_imports,
-)
+from extras import try_import
 
 
 def map_values(function, dictionary):

--- a/testtools/helpers.py
+++ b/testtools/helpers.py
@@ -1,19 +1,16 @@
 # Copyright (c) 2010-2012 testtools developers. See LICENSE for details.
 
 __all__ = [
-    'safe_hasattr',
     'try_import',
     'try_imports',
-    ]
+]
 
 import sys
 
-# Compat - removal announced in 0.9.25.
 from extras import (
-    safe_hasattr,
     try_import,
     try_imports,
-    )
+)
 
 
 def map_values(function, dictionary):

--- a/testtools/run.py
+++ b/testtools/run.py
@@ -12,9 +12,6 @@ import argparse
 from functools import partial
 import os.path
 import sys
-
-from extras import safe_hasattr
-
 import unittest
 
 from testtools import TextTestResult
@@ -183,7 +180,7 @@ class TestProgram(unittest.TestProgram):
             self.runTests()
         else:
             runner = self._get_runner()
-            if safe_hasattr(runner, 'list'):
+            if hasattr(runner, 'list'):
                 try:
                     runner.list(self.test, loader=self.testLoader)
                 except TypeError:

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -22,12 +22,9 @@ import itertools
 import sys
 import types
 import warnings
-
-from extras import (
-    safe_hasattr,
-    try_import,
-    )
 import unittest
+
+from extras import try_import
 
 from testtools import (
     content,
@@ -733,8 +730,10 @@ class TestCase(unittest.TestCase):
                 # the fixture.  Ideally this whole try/except is not
                 # really needed any more, however, we keep this code to
                 # remain compatible with the older setUp().
-                if (safe_hasattr(fixture, '_details') and
-                        fixture._details is not None):
+                if (
+                    hasattr(fixture, '_details') and
+                    fixture._details is not None
+                ):
                     gather_details(fixture.getDetails(), self.getDetails())
             except:
                 # Report the setUp exception, then raise the error during
@@ -903,7 +902,7 @@ def attr(*args):
         alter its id to enumerate the added attributes.
     """
     def decorate(fn):
-        if not safe_hasattr(fn, '__testtools_attrs'):
+        if not hasattr(fn, '__testtools_attrs'):
             fn.__testtools_attrs = set()
         fn.__testtools_attrs.update(args)
         return fn

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -21,17 +21,12 @@ import functools
 import itertools
 import sys
 import types
-import warnings
 import unittest
+import warnings
 
+from testtools.compat import reraise
+from testtools import content
 from testtools.helpers import try_import
-
-from testtools import (
-    content,
-    )
-from testtools.compat import (
-    reraise,
-    )
 from testtools.matchers import (
     Annotate,
     Contains,
@@ -48,11 +43,11 @@ from testtools.monkey import patch
 from testtools.runtest import (
     MultipleExceptions,
     RunTest,
-    )
+)
 from testtools.testresult import (
     ExtendedToOriginalDecorator,
     TestResult,
-    )
+)
 
 
 class TestSkipped(Exception):

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -24,7 +24,7 @@ import types
 import warnings
 import unittest
 
-from extras import try_import
+from testtools.helpers import try_import
 
 from testtools import (
     content,

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -22,6 +22,7 @@ __all__ = [
     'TimestampingStreamResult',
     ]
 
+import cgi
 import datetime
 import math
 from operator import methodcaller
@@ -36,10 +37,7 @@ from testtools.content import (
     TracebackContent,
 )
 from testtools.content_type import ContentType
-from testtools.helpers import try_import
 from testtools.tags import TagContext
-
-parse_mime_type = try_import('mimeparse.parse_mime_type')
 
 # circular import
 # from testtools.testcase import PlaceHolder
@@ -751,19 +749,35 @@ def _make_content_type(mime_type=None):
     testtools was emitting a bad encoding, and this works around it.
     Unfortunately, is also loses data - probably want to drop this in a few
     releases.
+
+    Based on mimeparse.py by Joe Gregorio (MIT License).
+
+    https://github.com/conneg/mimeparse/blob/master/mimeparse.py
     """
     # XXX: Not sure what release this was added, so "in a few releases" is
     # unactionable.
     if mime_type is None:
         mime_type = 'application/octet-stream'
 
-    primary, sub, parameters = parse_mime_type(mime_type)
+    full_type, parameters = cgi.parse_header(mime_type)
+    # Ensure any wildcards are valid.
+    if full_type == '*':
+        full_type = '*/*'
+
+    type_parts = full_type.split('/') if '/' in full_type else None
+    if not type_parts or len(type_parts) > 2:
+        raise Exception("Can't parse type '%s'" % full_type)
+
+    primary_type, sub_type = type_parts
+    primary_type = primary_type.strip()
+    sub_type = sub_type.strip()
+
     if 'charset' in parameters:
         if ',' in parameters['charset']:
             parameters['charset'] = parameters['charset'][
                 :parameters['charset'].find(',')]
 
-    return ContentType(primary, sub, parameters)
+    return ContentType(primary_type, sub_type, parameters)
 
 
 _status_map = {
@@ -796,8 +810,6 @@ class _StreamToTestRecord(StreamResult):
         """
         super().__init__()
         self.on_test = on_test
-        if parse_mime_type is None:
-            raise ImportError("mimeparse module missing.")
 
     def startTestRun(self):
         super().startTestRun()

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -29,9 +29,6 @@ import sys
 import unittest
 import warnings
 
-from testtools.helpers import try_import
-parse_mime_type = try_import('mimeparse.parse_mime_type')
-
 from testtools.compat import _b
 from testtools.content import (
     Content,
@@ -39,7 +36,11 @@ from testtools.content import (
     TracebackContent,
 )
 from testtools.content_type import ContentType
+from testtools.helpers import try_import
 from testtools.tags import TagContext
+
+parse_mime_type = try_import('mimeparse.parse_mime_type')
+
 # circular import
 # from testtools.testcase import PlaceHolder
 PlaceHolder = None

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -29,16 +29,15 @@ import sys
 import unittest
 import warnings
 
-from extras import try_import, try_imports
+from extras import try_import
 parse_mime_type = try_import('mimeparse.parse_mime_type')
-Queue = try_imports(['Queue.Queue', 'queue.Queue'])
 
 from testtools.compat import _b
 from testtools.content import (
     Content,
     text_content,
     TracebackContent,
-    )
+)
 from testtools.content_type import ContentType
 from testtools.tags import TagContext
 # circular import

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -29,7 +29,7 @@ import sys
 import unittest
 import warnings
 
-from extras import try_import
+from testtools.helpers import try_import
 parse_mime_type = try_import('mimeparse.parse_mime_type')
 
 from testtools.compat import _b

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -29,7 +29,7 @@ import sys
 import unittest
 import warnings
 
-from extras import safe_hasattr, try_import, try_imports
+from extras import try_import, try_imports
 parse_mime_type = try_import('mimeparse.parse_mime_type')
 Queue = try_imports(['Queue.Queue', 'queue.Queue'])
 
@@ -1481,7 +1481,7 @@ class ExtendedToOriginalDecorator:
         return getattr(self.decorated, 'failfast', self._failfast)
 
     def _set_failfast(self, value):
-        if safe_hasattr(self.decorated, 'failfast'):
+        if hasattr(self.decorated, 'failfast'):
             self.decorated.failfast = value
         else:
             self._failfast = value
@@ -1497,7 +1497,7 @@ class ExtendedToOriginalDecorator:
         return getattr(self.decorated, 'shouldStop', self._shouldStop)
 
     def _set_shouldStop(self, value):
-        if safe_hasattr(self.decorated, 'shouldStop'):
+        if hasattr(self.decorated, 'shouldStop'):
             self.decorated.shouldStop = value
         else:
             self._shouldStop = value
@@ -1723,7 +1723,7 @@ class ResourcedToStreamDecorator(ExtendedToStreamDecorator):
 
         # If the resource implements the TestResourceManager.id() API, let's
         # use it, otherwise fallback to the class name.
-        if safe_hasattr(resource, "id"):
+        if hasattr(resource, "id"):
             resource_id = resource.id()
         else:
             resource_id = "{}.{}".format(

--- a/testtools/tests/helpers.py
+++ b/testtools/tests/helpers.py
@@ -8,8 +8,6 @@ __all__ = [
 
 import sys
 
-from extras import safe_hasattr
-
 from testtools import TestResult
 from testtools.content import StackLinesContent
 from testtools.matchers import (
@@ -20,9 +18,6 @@ from testtools.matchers import (
 )
 from testtools import runtest
 
-
-# Importing to preserve compatibility.
-safe_hasattr
 
 # GZ 2010-08-12: Don't do this, pointlessly creates an exc_info cycle
 try:

--- a/testtools/tests/test_distutilscmd.py
+++ b/testtools/tests/test_distutilscmd.py
@@ -4,17 +4,14 @@
 
 from distutils.dist import Distribution
 
-from testtools.helpers import try_import
-
-from testtools.compat import (
-    _b,
-    )
-fixtures = try_import('fixtures')
-
 import testtools
-from testtools import TestCase
+from testtools.compat import _b
 from testtools.distutilscmd import TestCommand
+from testtools.helpers import try_import
 from testtools.matchers import MatchesRegex
+from testtools import TestCase
+
+fixtures = try_import('fixtures')
 
 
 if fixtures:

--- a/testtools/tests/test_distutilscmd.py
+++ b/testtools/tests/test_distutilscmd.py
@@ -4,7 +4,7 @@
 
 from distutils.dist import Distribution
 
-from extras import try_import
+from testtools.helpers import try_import
 
 from testtools.compat import (
     _b,

--- a/testtools/tests/test_fixturesupport.py
+++ b/testtools/tests/test_fixturesupport.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from extras import try_import
+from testtools.helpers import try_import
 
 from testtools import (
     TestCase,

--- a/testtools/tests/test_fixturesupport.py
+++ b/testtools/tests/test_fixturesupport.py
@@ -2,14 +2,13 @@
 
 import unittest
 
-from testtools.helpers import try_import
-
 from testtools import (
     TestCase,
     content,
     content_type,
     )
 from testtools.compat import _b
+from testtools.helpers import try_import
 from testtools.matchers import (
     Contains,
     Equals,
@@ -20,6 +19,7 @@ from testtools.testresult.doubles import (
 
 fixtures = try_import('fixtures')
 LoggingFixture = try_import('fixtures.tests.helpers.LoggingFixture')
+
 
 class TestFixtureSupport(TestCase):
 

--- a/testtools/tests/test_run.py
+++ b/testtools/tests/test_run.py
@@ -9,19 +9,18 @@ from textwrap import dedent
 import unittest
 from unittest import TestSuite
 
-from testtools.helpers import try_import
-fixtures = try_import('fixtures')
-testresources = try_import('testresources')
-import unittest
-
 import testtools
 from testtools import TestCase, run, skipUnless
 from testtools.compat import _b
+from testtools.helpers import try_import
 from testtools.matchers import (
     Contains,
     DocTestMatches,
     MatchesRegex,
 )
+
+fixtures = try_import('fixtures')
+testresources = try_import('testresources')
 
 
 if fixtures:

--- a/testtools/tests/test_run.py
+++ b/testtools/tests/test_run.py
@@ -4,9 +4,10 @@
 
 import doctest
 import io
-from unittest import TestSuite
 import sys
 from textwrap import dedent
+import unittest
+from unittest import TestSuite
 
 from extras import try_import
 fixtures = try_import('fixtures')
@@ -15,14 +16,12 @@ import unittest
 
 import testtools
 from testtools import TestCase, run, skipUnless
-from testtools.compat import (
-    _b,
-    )
+from testtools.compat import _b
 from testtools.matchers import (
     Contains,
     DocTestMatches,
     MatchesRegex,
-    )
+)
 
 
 if fixtures:

--- a/testtools/tests/test_run.py
+++ b/testtools/tests/test_run.py
@@ -9,7 +9,7 @@ from textwrap import dedent
 import unittest
 from unittest import TestSuite
 
-from extras import try_import
+from testtools.helpers import try_import
 fixtures = try_import('fixtures')
 testresources = try_import('testresources')
 import unittest

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -20,10 +20,6 @@ import tempfile
 import threading
 from unittest import TestSuite
 
-from testtools.helpers import try_import
-
-testresources = try_import('testresources')
-
 from testtools import (
     CopyStreamResult,
     ExtendedToOriginalDecorator,
@@ -61,6 +57,7 @@ from testtools.content import (
     TracebackContent,
     )
 from testtools.content_type import ContentType, UTF8_TEXT
+from testtools.helpers import try_import
 from testtools.matchers import (
     AllMatch,
     Contains,
@@ -90,6 +87,8 @@ from testtools.testresult.real import (
     _merge_tags,
     utc,
     )
+
+testresources = try_import('testresources')
 
 
 def make_erroring_test():

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -7,19 +7,20 @@ __metaclass__ = type
 import codecs
 import datetime
 import doctest
-from itertools import chain, combinations
 import io
+from itertools import chain
+from itertools import combinations
 import os
 import platform
+from queue import Queue
 import re
 import shutil
 import sys
 import tempfile
 import threading
 from unittest import TestSuite
-from extras import try_imports, try_import
 
-Queue = try_imports(['Queue.Queue', 'queue.Queue'])
+from extras import try_import
 
 testresources = try_import('testresources')
 

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -20,7 +20,7 @@ import tempfile
 import threading
 from unittest import TestSuite
 
-from extras import try_import
+from testtools.helpers import try_import
 
 testresources = try_import('testresources')
 

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -17,7 +17,7 @@ import sys
 import tempfile
 import threading
 from unittest import TestSuite
-from extras import safe_hasattr, try_imports, try_import
+from extras import try_imports, try_import
 
 Queue = try_imports(['Queue.Queue', 'queue.Queue'])
 
@@ -2191,7 +2191,7 @@ class TestExtendedToOriginalResultDecorator(
         self.make_26_result()
         self.assertEqual(False, self.converter.failfast)
         self.converter.failfast = True
-        self.assertFalse(safe_hasattr(self.converter.decorated, 'failfast'))
+        self.assertFalse(hasattr(self.converter.decorated, 'failfast'))
 
     def test_failfast_py27(self):
         self.make_27_result()

--- a/testtools/tests/test_testsuite.py
+++ b/testtools/tests/test_testsuite.py
@@ -6,8 +6,6 @@ import doctest
 from pprint import pformat
 import unittest
 
-from testtools.helpers import try_import
-
 from testtools import (
     ConcurrentTestSuite,
     ConcurrentStreamTestSuite,
@@ -16,10 +14,11 @@ from testtools import (
     TestByTestResult,
     TestCase,
     )
+from testtools.helpers import try_import
 from testtools.matchers import DocTestMatches, Equals
+from testtools.testresult.doubles import StreamResult as LoggingStream
 from testtools.testsuite import FixtureSuite, sorted_tests
 from testtools.tests.helpers import LoggingResult
-from testtools.testresult.doubles import StreamResult as LoggingStream
 
 FunctionFixture = try_import('fixtures.FunctionFixture')
 

--- a/testtools/tests/test_testsuite.py
+++ b/testtools/tests/test_testsuite.py
@@ -6,7 +6,7 @@ import doctest
 from pprint import pformat
 import unittest
 
-from extras import try_import
+from testtools.helpers import try_import
 
 from testtools import (
     ConcurrentTestSuite,

--- a/testtools/tests/twistedsupport/_helpers.py
+++ b/testtools/tests/twistedsupport/_helpers.py
@@ -4,7 +4,7 @@ __all__ = [
     'NeedsTwistedTestCase',
 ]
 
-from extras import try_import
+from testtools.helpers import try_import
 from testtools import TestCase
 
 defer = try_import('twisted.internet.defer')

--- a/testtools/tests/twistedsupport/test_deferred.py
+++ b/testtools/tests/twistedsupport/test_deferred.py
@@ -3,7 +3,6 @@
 """Tests for testtools._deferred."""
 
 from testtools.helpers import try_import
-
 from testtools.matchers import (
     Equals,
     MatchesException,

--- a/testtools/tests/twistedsupport/test_deferred.py
+++ b/testtools/tests/twistedsupport/test_deferred.py
@@ -2,7 +2,7 @@
 
 """Tests for testtools._deferred."""
 
-from extras import try_import
+from testtools.helpers import try_import
 
 from testtools.matchers import (
     Equals,

--- a/testtools/tests/twistedsupport/test_matchers.py
+++ b/testtools/tests/twistedsupport/test_matchers.py
@@ -2,7 +2,7 @@
 
 """Tests for Deferred matchers."""
 
-from extras import try_import
+from testtools.helpers import try_import
 
 from testtools.content import TracebackContent
 from testtools.matchers import (

--- a/testtools/tests/twistedsupport/test_matchers.py
+++ b/testtools/tests/twistedsupport/test_matchers.py
@@ -2,9 +2,8 @@
 
 """Tests for Deferred matchers."""
 
-from testtools.helpers import try_import
-
 from testtools.content import TracebackContent
+from testtools.helpers import try_import
 from testtools.matchers import (
     AfterPreprocessing,
     Equals,

--- a/testtools/tests/twistedsupport/test_runtest.py
+++ b/testtools/tests/twistedsupport/test_runtest.py
@@ -5,13 +5,12 @@
 import os
 import signal
 
-from testtools.helpers import try_import
-
 from testtools import (
     skipIf,
     TestCase,
     TestResult,
     )
+from testtools.helpers import try_import
 from testtools.matchers import (
     AfterPreprocessing,
     Contains,

--- a/testtools/tests/twistedsupport/test_runtest.py
+++ b/testtools/tests/twistedsupport/test_runtest.py
@@ -5,7 +5,7 @@
 import os
 import signal
 
-from extras import try_import
+from testtools.helpers import try_import
 
 from testtools import (
     skipIf,

--- a/testtools/tests/twistedsupport/test_spinner.py
+++ b/testtools/tests/twistedsupport/test_spinner.py
@@ -5,7 +5,7 @@
 import os
 import signal
 
-from extras import try_import
+from testtools.helpers import try_import
 
 from testtools import skipIf
 from testtools.matchers import (

--- a/testtools/tests/twistedsupport/test_spinner.py
+++ b/testtools/tests/twistedsupport/test_spinner.py
@@ -6,7 +6,6 @@ import os
 import signal
 
 from testtools.helpers import try_import
-
 from testtools import skipIf
 from testtools.matchers import (
     Equals,

--- a/testtools/testsuite.py
+++ b/testtools/testsuite.py
@@ -12,13 +12,10 @@ __all__ = [
 
 from collections import Counter
 from pprint import pformat
+from queue import Queue
 import sys
 import threading
 import unittest
-
-from extras import try_imports
-# This is just to let setup.py work, as testtools is imported in setup.py.
-Queue = try_imports(['Queue.Queue', 'queue.Queue'])
 
 import testtools
 

--- a/testtools/testsuite.py
+++ b/testtools/testsuite.py
@@ -16,7 +16,7 @@ import sys
 import threading
 import unittest
 
-from extras import safe_hasattr, try_imports
+from extras import try_imports
 # This is just to let setup.py work, as testtools is imported in setup.py.
 Queue = try_imports(['Queue.Queue', 'queue.Queue'])
 
@@ -235,7 +235,7 @@ def _flatten_tests(suite_or_case, unpack_outer=False):
             suite_id = test.id()
             break
         # If it has a sort_tests method, call that.
-        if safe_hasattr(suite_or_case, 'sort_tests'):
+        if hasattr(suite_or_case, 'sort_tests'):
             suite_or_case.sort_tests()
         return [(suite_id, suite_or_case)]
 
@@ -282,10 +282,10 @@ def filter_by_ids(suite_or_case, test_ids):
     than guessing how to reconstruct a new suite.
     """
     # Compatible objects
-    if safe_hasattr(suite_or_case, 'filter_by_ids'):
+    if hasattr(suite_or_case, 'filter_by_ids'):
         return suite_or_case.filter_by_ids(test_ids)
     # TestCase objects.
-    if safe_hasattr(suite_or_case, 'id'):
+    if hasattr(suite_or_case, 'id'):
         if suite_or_case.id() in test_ids:
             return suite_or_case
         else:

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,13 @@
 [tox]
 envlist = py35,py36,py37,py38,py39,pypy3
 minversion = 1.6
-skipsdist = True
-
 
 [testenv]
 usedevelop = True
-install_command = pip install -U {opts} {packages}
-setenv = VIRTUAL_ENV={envdir}
-
 deps =
   sphinx
   Twisted
 extras =
   test
-
 commands =
   python -m testtools.run testtools.tests.test_suite


### PR DESCRIPTION
I want to get to a point where fixtures and testtools don't form a circular
dependency chain. Before we can get there though, there's a lot more things
that appear to need cleaning up, namely our dependency on testtools2, extras,
and mimeparse, all of which are effectively EOL.