### PR TITLE
Fix tests with Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, pypy3]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev, pypy3]
 
     steps:
       - uses: actions/checkout@v2

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -2667,6 +2667,8 @@ class TestNonAsciiResults(TestCase):
         """Syntax errors should still have fancy special-case formatting"""
         if platform.python_implementation() == "PyPy":
             spaces = '           '
+        elif sys.version_info >= (3, 10):
+            spaces = '        '
         else:
             spaces = '          '
         textoutput = self._test_external_case("exec ('f(a, b c)')")

--- a/testtools/tests/test_testsuite.py
+++ b/testtools/tests/test_testsuite.py
@@ -181,7 +181,7 @@ class TestConcurrentStreamTestSuiteRun(TestCase):
     test.run(process_result)
 """, doctest.ELLIPSIS))
         self.assertThat(events[3][6].decode('utf8'), DocTestMatches("""\
-TypeError: run() takes ...1 ...argument...2...given...
+TypeError: ...run() takes ...1 ...argument...2...given...
 """, doctest.ELLIPSIS))
         events = [event[0:10] + (None,) for event in events]
         events[1] = events[1][:6] + (None,) + events[1][7:]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,py39,pypy3
+envlist = py35,py36,py37,py38,py39,310,pypy3
 minversion = 1.6
 
 [testenv]


### PR DESCRIPTION
In Python 3, error messages have become a bit more precise. For
instance, the following code snippet: