### PR TITLE
Fix setuptools warnings

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,10 @@
 [metadata]
 name = testtools
 summary = Extensions to the Python standard library unit testing framework
-home-page = https://github.com/testing-cabal/testtools
-description-file = doc/overview.rst
+home_page = https://github.com/testing-cabal/testtools
+description_file = doc/overview.rst
 author = Jonathan M. Lange
-author-email = jml+testtools@mumak.net
+author_email = jml+testtools@mumak.net
 classifier = 
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers


### PR DESCRIPTION
Shows up in commands using setuptools:

# master

```console
$ python setup.py --name
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'home-page' will not be supported in future versions. Please use the underscore name 'home_page' instead
  warnings.warn(
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  warnings.warn(
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'author-email' will not be supported in future versions. Please use the underscore name 'author_email' instead
  warnings.warn(
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'home-page' will not be supported in future versions. Please use the underscore name 'home_page' instead
  warnings.warn(
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  warnings.warn(
/Library/Frameworks/Python.framework/Versions/3.9/lib/python3.9/site-packages/setuptools/dist.py:691: UserWarning: Usage of dash-separated 'author-email' will not be supported in future versions. Please use the underscore name 'author_email' instead
  warnings.warn(
testtools
```

# PR

```console
$ python setup.py --name
testtools
```
