### PR TITLE
testtools.compat: provide BytesIO, StringIO again

### DIFF
--- a/testtools/compat.py
+++ b/testtools/compat.py
@@ -8,6 +8,8 @@ __all__ = [
     'advance_iterator',
     'reraise',
     'unicode_output_stream',
+    'StringIO',
+    'BytesIO',
     ]
 
 import codecs
@@ -16,6 +18,8 @@ import locale
 import os
 import sys
 import unicodedata
+# ensure retrocompatibility < 3.10
+from io import StringIO, BytesIO
 
 
 def reraise(exc_class, exc_obj, exc_tb, _marker=object()):

--- a/testtools/compat.py
+++ b/testtools/compat.py
@@ -18,7 +18,7 @@ import locale
 import os
 import sys
 import unicodedata
-# ensure retrocompatibility < 3.10
+# Ensure retro-compatibility with older testtools releases
 from io import StringIO, BytesIO
 
 
@@ -153,5 +153,4 @@ def _get_exception_encoding():
     #                no benefit in asking more than once as it's a global
     #                setting that can change after the message is formatted.
     return locale.getlocale(locale.LC_MESSAGES)[1] or "ascii"
-
 


### PR DESCRIPTION
This allows projects dependent on testtools.compat some respite if
they haven't been updated for python 3.10 yet. 