### PR TITLE
Note Python 3.5 is EOL and will be dropped after the next release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -12,6 +12,8 @@ Improvements
 * Add support for Python 3.9.
   (Hugo van Kemenade)
 
+* Python 3.5 has reached end-of-life and this is the last release to support it.
+
 * The skip, skipIf, and skipUnless decorators can now be used as class
   decorators as well as test method decorators, just as they can in
   unittest.
@@ -580,7 +582,7 @@ experimental and we might need to break it if it turns out to be unsuitable.
 
 Improvements
 ------------
-* ``assertRaises`` works properly for exception classes that have custom 
+* ``assertRaises`` works properly for exception classes that have custom
   metaclasses
 
 * ``ConcurrentTestSuite`` was silently eating exceptions that propagate from
@@ -767,14 +769,14 @@ Improvements
 Changes
 -------
 
-* ``testtools.run discover`` will now sort the tests it discovered. This is a 
+* ``testtools.run discover`` will now sort the tests it discovered. This is a
   workaround for http://bugs.python.org/issue16709. Non-standard test suites
   are preserved, and their ``sort_tests()`` method called (if they have such an
   attribute). ``testtools.testsuite.sorted_tests(suite, True)`` can be used by
   such suites to do a local sort. (Robert Collins, #1091512)
 
 * ``ThreadsafeForwardingResult`` now defines a stub ``progress`` method, which
-  fixes ``testr run`` of streams containing progress markers (by discarding the 
+  fixes ``testr run`` of streams containing progress markers (by discarding the
   progress data). (Robert Collins, #1019165)
 
 0.9.23
@@ -1594,7 +1596,7 @@ Improvements
   systems where os.sep is not '/'.
 
 * When a cleanUp or tearDown exception occurs, it is now accumulated as a new
-  traceback in the test details, rather than as a separate call to addError / 
+  traceback in the test details, rather than as a separate call to addError /
   addException. This makes testtools work better with most TestResult objects
   and fixes bug #335816.
 


### PR DESCRIPTION
As noted in https://github.com/testing-cabal/testtools/pull/309#pullrequestreview-682339286, the next 2.5.0 release be the last to support EOL Python 3.5.

Note this in the NEWS file to warn any remaining 3.5 users.