### PR TITLE
Upgrade asserts with teyit for Python 3.11 compatibility

### DIFF
--- a/testtools/tests/test_content.py
+++ b/testtools/tests/test_content.py
@@ -287,7 +287,7 @@ class TestStacktraceContent(TestCase):
 
     def test_top_frame_is_skipped_when_no_stack_is_specified(self):
         actual = StacktraceContent().as_text()
-        self.assertTrue('testtools/content.py' not in actual)
+        self.assertNotIn('testtools/content.py', actual)
 
 
 class TestAttachFile(TestCase):

--- a/testtools/tests/test_monkey.py
+++ b/testtools/tests/test_monkey.py
@@ -33,9 +33,9 @@ class MonkeyPatcherTest(TestCase):
 
         # We can't assert that all state is unchanged, but at least we can
         # check our test object.
-        self.assertEquals(self.original_object.foo, self.test_object.foo)
-        self.assertEquals(self.original_object.bar, self.test_object.bar)
-        self.assertEquals(self.original_object.baz, self.test_object.baz)
+        self.assertEqual(self.original_object.foo, self.test_object.foo)
+        self.assertEqual(self.original_object.bar, self.test_object.bar)
+        self.assertEqual(self.original_object.baz, self.test_object.baz)
 
     def test_construct_with_patches(self):
         # Constructing a 'MonkeyPatcher' with patches adds all of the given
@@ -43,23 +43,23 @@ class MonkeyPatcherTest(TestCase):
         patcher = MonkeyPatcher((self.test_object, 'foo', 'haha'),
                                 (self.test_object, 'bar', 'hehe'))
         patcher.patch()
-        self.assertEquals('haha', self.test_object.foo)
-        self.assertEquals('hehe', self.test_object.bar)
-        self.assertEquals(self.original_object.baz, self.test_object.baz)
+        self.assertEqual('haha', self.test_object.foo)
+        self.assertEqual('hehe', self.test_object.bar)
+        self.assertEqual(self.original_object.baz, self.test_object.baz)
 
     def test_patch_existing(self):
         # Patching an attribute that exists sets it to the value defined in the
         # patch.
         self.monkey_patcher.add_patch(self.test_object, 'foo', 'haha')
         self.monkey_patcher.patch()
-        self.assertEquals(self.test_object.foo, 'haha')
+        self.assertEqual(self.test_object.foo, 'haha')
 
     def test_patch_non_existing(self):
         # Patching a non-existing attribute sets it to the value defined in
         # the patch.
         self.monkey_patcher.add_patch(self.test_object, 'doesntexist', 'value')
         self.monkey_patcher.patch()
-        self.assertEquals(self.test_object.doesntexist, 'value')
+        self.assertEqual(self.test_object.doesntexist, 'value')
 
     def test_restore_non_existing(self):
         # Restoring a value that didn't exist before the patch deletes the
@@ -76,18 +76,18 @@ class MonkeyPatcherTest(TestCase):
         self.monkey_patcher.add_patch(self.test_object, 'foo', 'blah')
         self.monkey_patcher.add_patch(self.test_object, 'foo', 'BLAH')
         self.monkey_patcher.patch()
-        self.assertEquals(self.test_object.foo, 'BLAH')
+        self.assertEqual(self.test_object.foo, 'BLAH')
         self.monkey_patcher.restore()
-        self.assertEquals(self.test_object.foo, self.original_object.foo)
+        self.assertEqual(self.test_object.foo, self.original_object.foo)
 
     def test_restore_twice_is_a_no_op(self):
         # Restoring an already-restored monkey patch is a no-op.
         self.monkey_patcher.add_patch(self.test_object, 'foo', 'blah')
         self.monkey_patcher.patch()
         self.monkey_patcher.restore()
-        self.assertEquals(self.test_object.foo, self.original_object.foo)
+        self.assertEqual(self.test_object.foo, self.original_object.foo)
         self.monkey_patcher.restore()
-        self.assertEquals(self.test_object.foo, self.original_object.foo)
+        self.assertEqual(self.test_object.foo, self.original_object.foo)
 
     def test_run_with_patches_decoration(self):
         # run_with_patches runs the given callable, passing in all arguments
@@ -99,8 +99,8 @@ class MonkeyPatcherTest(TestCase):
             return 'foo'
 
         result = self.monkey_patcher.run_with_patches(f, 1, 2, c=10)
-        self.assertEquals('foo', result)
-        self.assertEquals([(1, 2, 10)], log)
+        self.assertEqual('foo', result)
+        self.assertEqual([(1, 2, 10)], log)
 
     def test_repeated_run_with_patches(self):
         # We can call the same function with run_with_patches more than
@@ -111,28 +111,30 @@ class MonkeyPatcherTest(TestCase):
 
         self.monkey_patcher.add_patch(self.test_object, 'foo', 'haha')
         result = self.monkey_patcher.run_with_patches(f)
-        self.assertEquals(
+        self.assertEqual(
             ('haha', self.original_object.bar, self.original_object.baz),
-            result)
+            result
+        )
         result = self.monkey_patcher.run_with_patches(f)
-        self.assertEquals(
+        self.assertEqual(
             ('haha', self.original_object.bar, self.original_object.baz),
-            result)
+            result
+        )
 
     def test_run_with_patches_restores(self):
         # run_with_patches restores the original values after the function has
         # executed.
         self.monkey_patcher.add_patch(self.test_object, 'foo', 'haha')
-        self.assertEquals(self.original_object.foo, self.test_object.foo)
+        self.assertEqual(self.original_object.foo, self.test_object.foo)
         self.monkey_patcher.run_with_patches(lambda: None)
-        self.assertEquals(self.original_object.foo, self.test_object.foo)
+        self.assertEqual(self.original_object.foo, self.test_object.foo)
 
     def test_run_with_patches_restores_on_exception(self):
         # run_with_patches restores the original values even when the function
         # raises an exception.
         def _():
-            self.assertEquals(self.test_object.foo, 'haha')
-            self.assertEquals(self.test_object.bar, 'blahblah')
+            self.assertEqual(self.test_object.foo, 'haha')
+            self.assertEqual(self.test_object.bar, 'blahblah')
             raise RuntimeError("Something went wrong!")
 
         self.monkey_patcher.add_patch(self.test_object, 'foo', 'haha')
@@ -140,8 +142,8 @@ class MonkeyPatcherTest(TestCase):
 
         self.assertThat(lambda:self.monkey_patcher.run_with_patches(_),
             Raises(MatchesException(RuntimeError("Something went wrong!"))))
-        self.assertEquals(self.test_object.foo, self.original_object.foo)
-        self.assertEquals(self.test_object.bar, self.original_object.bar)
+        self.assertEqual(self.test_object.foo, self.original_object.foo)
+        self.assertEqual(self.test_object.bar, self.original_object.bar)
 
 
 class TestPatchHelper(TestCase):

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -349,9 +349,11 @@ class TestAssertions(TestCase):
 
         exception = self.assertRaises(RuntimeError, raiseError)
         self.assertEqual(1, len(raisedExceptions))
-        self.assertTrue(
-            exception is raisedExceptions[0],
-            "{!r} is not {!r}".format(exception, raisedExceptions[0]))
+        self.assertIs(
+            exception,
+            raisedExceptions[0],
+            '{!r} is not {!r}'.format(exception, raisedExceptions[0])
+        )
 
     def test_assertRaises_with_multiple_exceptions(self):
         # assertRaises((ExceptionOne, ExceptionTwo), function) asserts that
@@ -516,7 +518,7 @@ class TestAssertions(TestCase):
 
     def test_assertIs(self):
         # assertIs asserts that an object is identical to another object.
-        self.assertIs(None, None)
+        self.assertIsNone(None)
         some_list = [42]
         self.assertIs(some_list, some_list)
         some_object = object()
@@ -645,7 +647,7 @@ class TestAssertions(TestCase):
         test = Test("test")
         result = test.run()
         details = test.getDetails()
-        self.assertTrue("Failed expectation" in details)
+        self.assertIn('Failed expectation', details)
 
     def test__force_failure_fails_test(self):
         class Test(TestCase):
@@ -1097,7 +1099,7 @@ class TestExpectedFailure(TestWithDetails):
         class ReferenceTest(TestCase):
             @unittest.expectedFailure
             def test_fails_expectedly(self):
-                self.assertEquals(1, 0)
+                self.assertEqual(1, 0)
 
         test = ReferenceTest('test_fails_expectedly')
         result = test.run()
@@ -1107,7 +1109,7 @@ class TestExpectedFailure(TestWithDetails):
         class ReferenceTest(TestCase):
             @unittest.expectedFailure
             def test_passes_unexpectedly(self):
-                self.assertEquals(1, 1)
+                self.assertEqual(1, 1)
 
         test = ReferenceTest('test_passes_unexpectedly')
         result = test.run()
@@ -1687,7 +1689,7 @@ class TestSkipping(TestCase):
     def check_test_does_not_run_setup(self, test, reason):
         result = test.run()
         self.assertTrue(result.wasSuccessful())
-        self.assertTrue(reason in result.skip_reasons, result.skip_reasons)
+        self.assertIn(reason, result.skip_reasons, result.skip_reasons)
         self.assertFalse(test.setup_ran)
 
     def test_testtools_skip_decorator_does_not_run_setUp(self):


### PR DESCRIPTION
Use https://github.com/isidentical/teyit to upgrade unittest asserts for better error messages.

Also `assertEquals` has been removed in 3.11, so use `assertEqual` instead.

https://docs.python.org/3.11/whatsnew/3.11.html

---

There are still some other things needed for 3.11 compatibility but this is a first step.