### PR TITLE
doc: Remove references to unittest2

### DIFF
--- a/doc/for-framework-folk.rst
+++ b/doc/for-framework-folk.rst
@@ -133,10 +133,7 @@ DecorateTestCaseResult
 This object calls out to your code when ``run`` / ``__call__`` are called and
 allows the result object that will be used to run the test to be altered. This
 is very useful when working with a test runner that doesn't know your test case
-requirements. For instance, it can be used to inject a ``unittest2`` compatible
-adapter when someone attempts to run your test suite with a ``TestResult`` that
-does not support ``addSkip`` or other ``unittest2`` methods. Similarly it can
-aid the migration to ``StreamResult``.
+requirements. For instance, it can aid the migration to ``StreamResult``.
 
 e.g.::
 

--- a/doc/for-test-authors.rst
+++ b/doc/for-test-authors.rst
@@ -84,7 +84,6 @@ of them will happily run testtools tests.  In particular:
 * testrepository_
 * Trial_
 * nose_
-* unittest2_
 * `zope.testrunner`_ (aka zope.testing)
 
 From now on, we'll assume that you know how to run your tests.
@@ -1463,7 +1462,6 @@ Here, ``repr(nullary)`` will be the same as ``repr(f)``.
 .. _testrepository: https://launchpad.net/testrepository
 .. _Trial: http://twistedmatrix.com/documents/current/core/howto/testing.html
 .. _nose: http://somethingaboutorange.com/mrl/projects/nose/
-.. _unittest2: http://pypi.python.org/pypi/unittest2
 .. _zope.testrunner: http://pypi.python.org/pypi/zope.testrunner/
 .. _xUnit test patterns: http://xunitpatterns.com/
 .. _fixtures: http://pypi.python.org/pypi/fixtures

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ home_page = https://github.com/testing-cabal/testtools
 description_file = doc/overview.rst
 author = Jonathan M. Lange
 author_email = jml+testtools@mumak.net
-classifier = 
+classifier =
     Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     License :: OSI Approved :: MIT License


### PR DESCRIPTION
Remove some leftover references to `unittest2`.
