### PR TITLE
Provide a ``testtools[twisted]`` extra

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,8 +34,8 @@ jobs:
         run: |
           python3 -m pip install -U pip
           python3 -m pip install -U wheel setuptools
-          python3 -m pip install sphinx Twisted
-          python3 -m pip install ".[test]"
+          python3 -m pip install sphinx
+          python3 -m pip install ".[test,twisted]"
 
       - name: Tests
         run: |

--- a/NEWS
+++ b/NEWS
@@ -18,6 +18,9 @@ Improvements
 * Distutils integration is deprecated and will be removed in the next major
   version.
 
+* Provide a ``testtools[twisted]`` extra documenting dependencies needed for
+  ``testtools.twistedsupport``.
+
 2.5.0
 ~~~~~
 

--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,8 @@ tested on Linux and macOS.
 Optional Dependencies
 ---------------------
 
-If you would like to use our Twisted support, then you will need Twisted.
+If you would like to use our Twisted support, then you will need the
+``testtools[twisted]`` extra.
 
 If you want to use ``fixtures`` then you can either install fixtures (e.g. from
 https://launchpad.net/python-fixtures or https://pypi.python.org/pypi/fixtures)

--- a/doc/twisted-support.rst
+++ b/doc/twisted-support.rst
@@ -3,7 +3,8 @@
 Twisted support
 ===============
 
-testtools provides support for testing Twisted code.
+testtools provides support for testing Twisted code.  Install the
+``testtools[twisted]`` extra to use this.
 
 
 Matching Deferreds

--- a/readthedocs-requirements.txt
+++ b/readthedocs-requirements.txt
@@ -6,5 +6,4 @@
 # that it knows exactly what to install in order to render the full
 # documentation.
 
-testtools[test]
-Twisted
+testtools[test,twisted]

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,8 @@ classifier =
 test =
   testscenarios
   testresources
+twisted =
+  Twisted
 
 [files]
 packages = testtools

--- a/tox.ini
+++ b/tox.ini
@@ -6,8 +6,8 @@ minversion = 1.6
 usedevelop = True
 deps =
   sphinx
-  Twisted
 extras =
   test
+  twisted
 commands =
   python -W once -m testtools.run testtools.tests.test_suite


### PR DESCRIPTION
This documents dependencies needed for `testtools.twistedsupport`.  At
the moment this is just `Twisted`, but it generally seems a good idea to
put this sort of thing in an official extra rather than having it be
documented ad-hoc.