### PR TITLE
Fix inclusion of NEWS in Sphinx documentation

### DIFF
--- a/doc/news.rst
+++ b/doc/news.rst
@@ -1,0 +1,1 @@
+.. include:: ../NEWS


### PR DESCRIPTION
`make html-sphinx` previously warned:

    .../doc/index.rst:20: WARNING: toctree contains reference to
    nonexisting document 'news'