### PR TITLE
Replace deprecated assertRaisesRegexp with assertRaisesRegex

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Tests
         run: |
-          python -m testtools.run testtools.tests.test_suite
+          python -W once -m testtools.run testtools.tests.test_suite
 
       - name: Docs
         run: |

--- a/testtools/tests/matchers/test_filesystem.py
+++ b/testtools/tests/matchers/test_filesystem.py
@@ -223,7 +223,7 @@ class TestSamePath(TestCase, PathHelpers):
         try:
             os.symlink(source, target)
         except (AttributeError, NotImplementedError):
-            self.skip("No symlink support")
+            self.skipTest("No symlink support")
         self.assertThat(source, SamePath(target))
         self.assertThat(target, SamePath(source))
 

--- a/testtools/tests/samplecases.py
+++ b/testtools/tests/samplecases.py
@@ -96,7 +96,7 @@ def _failure(case):
 
 
 def _skip(case):
-    case.skip('arbitrary skip message')
+    case.skipTest('arbitrary skip message')
 
 
 def _expected_failure(case):

--- a/testtools/tests/test_compat.py
+++ b/testtools/tests/test_compat.py
@@ -39,7 +39,7 @@ class TestUnicodeOutputStream(testtools.TestCase):
     def setUp(self):
         super().setUp()
         if sys.platform == "cli":
-            self.skip("IronPython shouldn't wrap streams to do encoding")
+            self.skipTest("IronPython shouldn't wrap streams to do encoding")
 
     def test_no_encoding_becomes_ascii(self):
         """A stream with no encoding attribute gets ascii/replace strings"""

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -1455,7 +1455,7 @@ class TestSkipping(TestCase):
 
     def test_skip_causes_skipException(self):
         self.assertThat(
-            lambda: self.skip("Skip this test"),
+            lambda: self.skipTest("Skip this test"),
             Raises(MatchesException(self.skipException)))
 
     def test_can_use_skipTest(self):

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -386,24 +386,24 @@ class TestAssertions(TestCase):
             Raises(
                 MatchesException(self.failureException, '.*{!r}.*'.format(foo))))
 
-    def test_assertRaisesRegexp(self):
-        # assertRaisesRegexp asserts that function raises particular exception
+    def test_assertRaisesRegex(self):
+        # assertRaisesRegex asserts that function raises particular exception
         # with particular message.
-        self.assertRaisesRegexp(RuntimeError, r"M\w*e", self.raiseError,
-                                RuntimeError, "Message")
+        self.assertRaisesRegex(RuntimeError, r"M\w*e", self.raiseError,
+                               RuntimeError, "Message")
 
-    def test_assertRaisesRegexp_wrong_error_type(self):
+    def test_assertRaisesRegex_wrong_error_type(self):
         # If function raises an exception of unexpected type,
-        # assertRaisesRegexp re-raises it.
-        self.assertRaises(ValueError, self.assertRaisesRegexp, RuntimeError,
+        # assertRaisesRegex re-raises it.
+        self.assertRaises(ValueError, self.assertRaisesRegex, RuntimeError,
                           r"M\w*e", self.raiseError, ValueError, "Message")
 
-    def test_assertRaisesRegexp_wrong_message(self):
+    def test_assertRaisesRegex_wrong_message(self):
         # If function raises an exception with unexpected message
-        # assertRaisesRegexp fails.
+        # assertRaisesRegex fails.
         self.assertFails(
             '"Expected" does not match "Observed"',
-            self.assertRaisesRegexp, RuntimeError, "Expected",
+            self.assertRaisesRegex, RuntimeError, "Expected",
             self.raiseError, RuntimeError, "Observed")
 
     def assertFails(self, message, function, *args, **kwargs):

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -1566,7 +1566,7 @@ class TestTextTestResult(TestCase):
             DocTestMatches("...\nFAILED (failures=1)\n", doctest.ELLIPSIS))
 
     def test_stopTestRun_shows_details(self):
-        self.skip("Disabled per bug 1188420")
+        self.skipTest("Disabled per bug 1188420")
         def run_tests():
             self.result.startTestRun()
             make_erroring_test().run(self.result)
@@ -2518,7 +2518,7 @@ class TestNonAsciiResults(TestCase):
             # the file without closing it which breaks non-refcounted pythons
             codecs.lookup(encoding)
         except LookupError:
-            self.skip("Encoding unsupported by implementation: %r" % encoding)
+            self.skipTest("Encoding unsupported by implementation: %r" % encoding)
         f = codecs.open(os.path.join(self.dir, name + ".py"), "w", encoding)
         try:
             f.write(contents)
@@ -2568,7 +2568,7 @@ class TestNonAsciiResults(TestCase):
                    return u, u
             except (LookupError, UnicodeError):
                 pass
-        self.skip("Could not find a sample text for encoding: %r" % encoding)
+        self.skipTest("Could not find a sample text for encoding: %r" % encoding)
 
     def _as_output(self, text):
         return text

--- a/testtools/tests/test_testsuite.py
+++ b/testtools/tests/test_testsuite.py
@@ -253,7 +253,7 @@ class TestFixtureSuite(TestCase):
     def setUp(self):
         super().setUp()
         if FunctionFixture is None:
-            self.skip("Need fixtures")
+            self.skipTest("Need fixtures")
 
     def test_fixture_suite(self):
         log = []

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ deps =
 extras =
   test
 commands =
-  python -m testtools.run testtools.tests.test_suite
+  python -W once -m testtools.run testtools.tests.test_suite


### PR DESCRIPTION
I missed this in https://github.com/testing-cabal/testtools/pull/319.

* Python 3.1: `assertRaisesRegexp` was added ([docs](https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertRaisesRegex))
* Python 3.2: Renamed to `assertRaisesRegex` and `assertRaisesRegexp` deprecated ([docs](https://docs.python.org/3/library/unittest.html#deprecated-aliases))
* Python 3.12: `assertRaisesRegexp` is planned for removal ([PR](https://github.com/python/cpython/pull/92556)) (originally planned for 3.11 but postponed)

Also:

* Enable warnings in tests, so there's visibility for these ([for example](https://github.com/hugovk/testtools/runs/6737058042?check_suite_focus=true#step:6:8))
* Fix "DeprecationWarning: Only valid in 1.8.1 and earlier. Use skipTest instead."