### PR TITLE
Prevent AttributeError in TestCase.__eq__

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -273,7 +273,7 @@ class TestCase(unittest.TestCase):
         eq = getattr(unittest.TestCase, '__eq__', None)
         if eq is not None and not unittest.TestCase.__eq__(self, other):
             return False
-        return self.__dict__ == other.__dict__
+        return self.__dict__ == getattr(other, '__dict__', None)
 
     __hash__ = unittest.TestCase.__hash__
 

--- a/testtools/tests/test_testcase.py
+++ b/testtools/tests/test_testcase.py
@@ -5,6 +5,7 @@
 from doctest import ELLIPSIS
 from pprint import pformat
 import sys
+import _thread
 import unittest
 
 from testtools import (
@@ -89,6 +90,10 @@ class TestPlaceHolder(TestCase):
     def test_testcase_is_hashable(self):
         test = hash(self)
         self.assertEqual(unittest.TestCase.__hash__(self), test)
+
+    def test_testcase_equals_edgecase(self):
+        # Not all python objects have a __dict__ attribute
+        self.assertFalse(self == _thread.RLock())
 
     def test_repr_just_id(self):
         # repr(placeholder) shows you how the object was constructed.


### PR DESCRIPTION
Not all objects have a `__dict__` attribute.