### PR TITLE
Fix distutilscmd in Debian + Py 3.11

### DIFF
--- a/testtools/tests/test_distutilscmd.py
+++ b/testtools/tests/test_distutilscmd.py
@@ -50,7 +50,7 @@ class TestCommandTest(TestCase):
     def test_test_module(self):
         self.useFixture(SampleTestFixture())
         stdout = self.useFixture(fixtures.StringStream('stdout'))
-        dist = Distribution()
+        dist = Distribution(attrs={ 'packages': ['testtools'] })
         dist.script_name = 'setup.py'
         dist.script_args = ['test']
         dist.cmdclass = {'test': TestCommand}
@@ -70,7 +70,7 @@ OK
     def test_test_suite(self):
         self.useFixture(SampleTestFixture())
         stdout = self.useFixture(fixtures.StringStream('stdout'))
-        dist = Distribution()
+        dist = Distribution(attrs={ 'packages': ['testtools'] })
         dist.script_name = 'setup.py'
         dist.script_args = ['test']
         dist.cmdclass = {'test': TestCommand}


### PR DESCRIPTION
Under Debian, when attempting to run tests, the debian folder is found and conflicts with this error:

setuptools.errors.PackageDiscoveryError: Multiple top-level packages discovered in a flat-layout: ['debian', 'testtools'].

This patch fixes this (I already applied it in Debian, and it solved the issue for me).