### PR TITLE
Replace deprecated `cgi` module usage with `email`

### DIFF
--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -762,7 +762,7 @@ def _make_content_type(mime_type=None):
     msg = email.message.EmailMessage()
     msg['content-type'] = mime_type
 
-    full_type, parameters = msg.get_content_type(), msg['content-type'].params
+    full_type, parameters = msg.get_content_type(), dict(msg['content-type'].params)
     # Ensure any wildcards are valid.
     if full_type == '*':
         full_type = '*/*'

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -22,8 +22,8 @@ __all__ = [
     'TimestampingStreamResult',
     ]
 
-import cgi
 import datetime
+import email
 import math
 from operator import methodcaller
 import sys
@@ -759,7 +759,10 @@ def _make_content_type(mime_type=None):
     if mime_type is None:
         mime_type = 'application/octet-stream'
 
-    full_type, parameters = cgi.parse_header(mime_type)
+    msg = email.message.EmailMessage()
+    msg['content-type'] = mime_type
+
+    full_type, parameters = msg.get_content_type(), msg['content-type'].params
     # Ensure any wildcards are valid.
     if full_type == '*':
         full_type = '*/*'


### PR DESCRIPTION
In Python 3.11 the standard library `cgi` module was deprecated with a planned removal set for Python 3.13. In preparation for that removal, this commit removes the usage of this deprecated module and replaces it with the still supported standard library `email` module which is what the documentation points to as an alternative for how `cgi` was previously used. This should still be compatible with all the supported Python versions but will be more future proof and not emit any deprecation warnings with Python 3.11 anymore.