### PR TITLE
disperse: Fix tag format (now just X.Y.Z rather than testtools-X.Y.Z)

### DIFF
--- a/disperse.conf
+++ b/disperse.conf
@@ -1,5 +1,5 @@
 # See https://github.com/jelmer/disperse
 news_file: "NEWS"
 timeout_days: 5
-tag_name: "testtools-$VERSION"
+tag_name: "$VERSION"
 launchpad_project: "testtools"


### PR DESCRIPTION
disperse: Fix tag format (now just X.Y.Z rather than testtools-X.Y.Z)
