### PR TITLE
Reduce use of deprecated `distutils` module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,11 @@ classifier =
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Software Development :: Testing
 
+[options]
+install_requires =
+    # Purely to support the deprecated `TestCommand` until 3.0.
+    setuptools; python_version>='3.12'
+
 [extras]
 test =
   testscenarios

--- a/testtools/distutilscmd.py
+++ b/testtools/distutilscmd.py
@@ -5,8 +5,12 @@
 import sys
 import warnings
 
-from distutils.core import Command
-from distutils.errors import DistutilsOptionError
+try:
+    from setuptools import Command
+    from setuptools.errors import OptionError
+except ModuleNotFoundError:
+    from distutils.core import Command
+    from distutils.errors import DistutilsOptionError as OptionError
 
 from testtools.run import TestProgram, TestToolsTestRunner
 
@@ -47,12 +51,12 @@ class TestCommand(Command):
     def finalize_options(self):
         if self.test_suite is None:
             if self.test_module is None:
-                raise DistutilsOptionError(
+                raise OptionError(
                     "You must specify a module or a suite to run tests from")
             else:
                 self.test_suite = self.test_module+".test_suite"
         elif self.test_module:
-            raise DistutilsOptionError(
+            raise OptionError(
                 "You may specify a module or a suite, but not both")
         self.test_args = [self.test_suite]
         if self.verbose:


### PR DESCRIPTION
Per PEP 632, `distutils` is deprecated and most uses of it can be replaced by `setuptools`.  The only use within `testtools` is to support the deprecated `TestCommand` that's due to be removed in the next major, but in the meantime, adding a runtime dependency on `setuptools` for Python 3.12+ (which removed `distutils` entirely) allows it to continue working.

Fix #352.