### PR TITLE
Fix pypy tests in test_testresult.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", 3.11, 3.12, pypy3.10]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", 3.11, 3.12, pypy3.9, pypy3.10]
 
     steps:
       - uses: actions/checkout@v4

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -2669,13 +2669,11 @@ class TestNonAsciiResults(TestCase):
         """Syntax errors should still have fancy special-case formatting"""
         if platform.python_implementation() == "PyPy":
             spaces = '         '
-            marker = '^'
         elif sys.version_info >= (3, 10):
             spaces = '        '
-            marker = '^^^'
         else:
             spaces = '          '
-            marker = '^'
+        marker = '^^^' if sys.version_info >= (3, 10) else '^'
         textoutput = self._test_external_case("exec ('f(a, b c)')")
         self.assertIn(self._as_output(
             '  File "<string>", line 1\n'

--- a/testtools/tests/test_testresult.py
+++ b/testtools/tests/test_testresult.py
@@ -2668,7 +2668,7 @@ class TestNonAsciiResults(TestCase):
     def test_syntax_error(self):
         """Syntax errors should still have fancy special-case formatting"""
         if platform.python_implementation() == "PyPy":
-            spaces = '           '
+            spaces = '         '
             marker = '^'
         elif sys.version_info >= (3, 10):
             spaces = '        '


### PR DESCRIPTION
Fixes #333 

Test both supported versions of PyPy3.  https://www.pypy.org/download.html

~:-(. Both fail in similar ways.~

With two spaces less, pypy3.9 now passes but pypy3.10 fails.

With `marker = '^^^' if sys.version_info >= (3, 10) else '^'` everyone seems happy.

Perhaps add Py3.11, Py3.12, Pypy3.9, and Pypy3.10 to the `Required` tests below.

See https://github.com/testing-cabal/testtools/pull/356#issuecomment-1767718448 for the `Some checks haven’t completed yet` message below.