### PR TITLE
stdlib alignment

### DIFF
--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -21,6 +21,7 @@ import itertools
 import sys
 import types
 import unittest
+from unittest.case import SkipTest
 import warnings
 
 from testtools.compat import reraise
@@ -49,9 +50,15 @@ from testtools.testresult import (
 )
 
 
-class TestSkipped(Exception):
+class TestSkipped(SkipTest):
     """Raised within TestCase.run() when a test is skipped."""
-TestSkipped = try_import('unittest.case.SkipTest', TestSkipped)
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            'Use SkipTest from unittest instead.',
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
 
 class _UnexpectedSuccess(Exception):
@@ -218,7 +225,7 @@ class TestCase(unittest.TestCase):
         and an optional list of exception handlers.
     """
 
-    skipException = TestSkipped
+    skipException = SkipTest
 
     run_tests_with = RunTest
 
@@ -597,7 +604,8 @@ class TestCase(unittest.TestCase):
         :seealso addOnException:
         """
         if exc_info[0] not in [
-                self.skipException, _UnexpectedSuccess, _ExpectedFailure]:
+            self.skipException, _UnexpectedSuccess, _ExpectedFailure,
+        ]:
             self._report_traceback(exc_info, tb_label=tb_label)
         for handler in self.__exception_handlers:
             handler(exc_info)

--- a/testtools/testcase.py
+++ b/testtools/testcase.py
@@ -60,8 +60,6 @@ class _UnexpectedSuccess(Exception):
     Note that this exception is private plumbing in testtools' testcase
     module.
     """
-_UnexpectedSuccess = try_import(
-    'unittest.case._UnexpectedSuccess', _UnexpectedSuccess)
 
 
 class _ExpectedFailure(Exception):
@@ -70,8 +68,6 @@ class _ExpectedFailure(Exception):
     Note that this exception is private plumbing in testtools' testcase
     module.
     """
-_ExpectedFailure = try_import(
-    'unittest.case._ExpectedFailure', _ExpectedFailure)
 
 
 # Copied from unittest before python 3.4 release. Used to maintain

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,11 @@
 [tox]
-envlist = py36,py37,py38,py39,py310,py311,py312,pypy3
-minversion = 1.6
+envlist = py37,py38,py39,py310,py311,py312,pypy3
+minversion = 4.2
 
 [testenv]
 usedevelop = True
-deps =
-  sphinx
-  setuptools>=61
-  setuptools-scm
 extras =
   test
   twisted
 commands =
-  python -W once -m testtools.run testtools.tests.test_suite
+  python -W once -m testtools.run testtools.tests.test_suite {posargs}


### PR DESCRIPTION
Deprecate some legacy aliases and generally align us closer to the Python 3.12 stdlib `unittest` implementation.
