### PR TITLE
Handle breaking api change in Python 3.12.1

### DIFF
--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -227,7 +227,9 @@ class TestResult(unittest.TestResult):
         self._tags = TagContext(self._tags)
 
     def stopTest(self, test):
-        self._tags = self._tags.parent
+        # NOTE: In Python 3.12.1 skipped tests may not call startTest()
+        if self._tags is not None:
+            self._tags = self._tags.parent
         super().stopTest(test)
 
     @property
@@ -1608,7 +1610,9 @@ class ExtendedToOriginalDecorator:
         self.shouldStop = True
 
     def stopTest(self, test):
-        self._tags = self._tags.parent
+        # NOTE: In Python 3.12.1 skipped tests may not call startTest()
+        if self._tags is not None:
+            self._tags = self._tags.parent
         return self.decorated.stopTest(test)
 
     def stopTestRun(self):
@@ -1670,7 +1674,9 @@ class ExtendedToStreamDecorator(CopyStreamResult, StreamSummary, TestControl):
         self._tags = TagContext(self._tags)
 
     def stopTest(self, test):
-        self._tags = self._tags.parent
+        # NOTE: In Python 3.12.1 skipped tests may not call startTest()
+        if self._tags is not None:
+            self._tags = self._tags.parent
 
     def addError(self, test, err=None, details=None):
         self._check_args(err, details)


### PR DESCRIPTION
In Python 3.12.1 python/cpython#106588 was backported which changed the execution behavior of the unittest runner. After python/cpython#106588 startTest() is no longer being called if a test is skipped. This causes knock-on effects in testtools because the test result subclasses were assuming that startTest() was always called when stopTest() was called. To handle this change in behavior when running with Python 3.12.1 this commit adds a check to only deal with tags if they exist (when startTest() is run).