### PR TITLE
Prepare tests for upcoming twisted version

### DIFF
--- a/testtools/tests/twistedsupport/test_runtest.py
+++ b/testtools/tests/twistedsupport/test_runtest.py
@@ -16,7 +16,6 @@ from testtools.matchers import (
     Contains,
     ContainsAll,
     ContainsDict,
-    EndsWith,
     Equals,
     Is,
     KeysEqual,
@@ -749,7 +748,7 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
                     test,
                     {
                         "traceback": Not(Is(None)),
-                        "twisted-log": AsText(EndsWith(" foo\n")),
+                        "twisted-log": AsText(Contains(" foo\n")),
                     },
                 ),
                 ("stopTest", test),
@@ -790,7 +789,8 @@ class TestAsynchronousDeferredRunTest(NeedsTwistedTestCase):
         result = self.make_result()
         runner.run(result)
         self.assertThat(
-            messages, MatchesListwise([ContainsDict({"message": Equals(("foo",))})])
+            messages[0:1],
+            MatchesListwise([ContainsDict({"message": Equals(("foo",))})]),
         )
 
     def test_restore_observers(self):


### PR DESCRIPTION
Current twisted trunk (https://github.com/twisted/twisted/commit/49a649b6d8ead04dbe774918e660505998859efc) breaks two tests in the `twistedsupport` test suite, see the error log below. I was able to bisect the braking commit https://github.com/twisted/twisted/commit/1269e566ccffa5bba3006248e36ff09086fdccbe introduced in PR https://github.com/twisted/twisted/pull/12207. The `mainLoop` newly logs `Main loop terminated.` message even on exception, see https://github.com/twisted/twisted/commit/1269e566ccffa5bba3006248e36ff09086fdccbe#diff-c6cc886d2bcab963daa7b561a036e0bea05ef01ef3351f66489f1fffea94c1eaR702-R710 but both affected tests expect only `foo`.

This hackish PR tries to address the upcoming issue.

```
======================================================================
FAIL: testtools.tests.twistedsupport.test_runtest.TestAsynchronousDeferredRunTest.test_log_in_details
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/testtools/testtools/tests/twistedsupport/test_runtest.py", line 743, in test_log_in_details
    self.assertThat(
  File "/root/testtools/testtools/testcase.py", line 509, in assertThat
    raise mismatch_error
testtools.matchers._impl.MismatchError: Differences: [
Differences: [
Differences: {
  'twisted-log': '''\
2024-07-01 07:08:06+0000 [-] foo
2024-07-01 07:08:06+0000 [-] Main loop terminated.
''' does not end with '''\
 foo
'''.: after <function <lambda>> on <Content type=text/plain; charset="utf8", value=b'2024-07-01 07:08:06+0000 [-] foo\n2024-07-01 07:08:06+0000 [-] Main loop terminated.\n'>,
}
]
]
======================================================================
FAIL: testtools.tests.twistedsupport.test_runtest.TestAsynchronousDeferredRunTest.test_log_to_twisted
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/testtools/testtools/tests/twistedsupport/test_runtest.py", line 792, in test_log_to_twisted
    self.assertThat(
  File "/root/testtools/testtools/testcase.py", line 509, in assertThat
    raise mismatch_error
testtools.matchers._impl.MismatchError: Differences: [
len([{'system': '-', 'message': ('foo',), 'time': 1719817686.7797003, 'isError': 0, 'log_time': 1719817686.7797003, 'log_text': 'foo', 'log_format': '{log_text}', 'log_level': <LogLevel=info>, 'log_namespace': 'log_legacy', 'log_system': '-', 'format': '%(log_legacy)s', 'log_legacy': <twisted.logger._stdlib.StringifiableFromEvent object at 0x7f5393e0e5c0>}, {'log_logger': <Logger 'twisted.internet.base'>, 'log_level': <LogLevel=info>, 'log_namespace': 'twisted.internet.base', 'log_source': None, 'log_format': 'Main loop terminated.', 'log_time': 1719817686.7798698, 'message': (), 'time': 1719817686.7798698, 'system': '-', 'format': '%(log_legacy)s', 'log_legacy': <twisted.logger._stdlib.StringifiableFromEvent object at 0x7f5393e0d600>, 'isError': 0}]) != 1: Length mismatch
]

Ran 2627 tests in 0.913s
FAILED (failures=2)
```