### PR TITLE
Make version tuple major/minor/patch elements integers

### DIFF
--- a/testtools/__init__.py
+++ b/testtools/__init__.py
@@ -116,7 +116,7 @@ try:
     # This will fail with LookupError if the package is not installed in
     # editable mode or if Git is not installed.
     version = get_version(root="..", relative_to=__file__)
-    __version__ = tuple(version.split("."))
+    __version__ = tuple([int(v) if v.isdigit() else v for v in version.split(".")])
 except (ImportError, LookupError):
     # As a fallback, use the version that is hard-coded in the file.
     try:


### PR DESCRIPTION
Prior to this change, __version__ would be ("2", "7", "2", "...", "..."). This breaks version checks in e.g. breezy.