### PR TITLE
Stop using twisted.internet.defer.returnValue

### DIFF
--- a/testtools/twistedsupport/_runtest.py
+++ b/testtools/twistedsupport/_runtest.py
@@ -335,7 +335,7 @@ class AsynchronousDeferredRunTest(_DeferredRunTest):
                 exc_info = sys.exc_info()
                 self.case._report_traceback(exc_info)
                 last_exception = exc_info[1]
-        defer.returnValue(last_exception)
+        return last_exception
 
     def _make_spinner(self):
         """Make the `Spinner` to be used to run the tests."""


### PR DESCRIPTION
`defer.returnValue` was only needed in Python 2; in Python 3, a simple `return` is fine.

`twisted.internet.defer.returnValue` is deprecated as of Twisted 24.7.0.