### PR TITLE
doc: Bump minimum supported python version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ under the same license as Python, see LICENSE for details.
 Supported platforms
 -------------------
 
-* Python 3.7+ or PyPy3
+* Python 3.9+ or PyPy3
 
 If you would like to use testtools for earlier Pythons, consult the compatibility docs:
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -84,7 +84,7 @@ Cross-Python compatibility
 --------------------------
 
 testtools gives you the very latest in unit testing technology in a way that
-will work with Python 3.7+ and PyPy3.
+will work with Python 3.9+ and PyPy3.
 
 If you wish to use testtools with Python 2.4 or 2.5, then please use testtools
 0.9.15.

--- a/scripts/all-pythons
+++ b/scripts/all-pythons
@@ -89,5 +89,5 @@ def now():
 if __name__ == '__main__':
     sys.path.append(ROOT)
     result = TestProtocolClient(sys.stdout)
-    for version in '3.7 3.8 3.9 3.10 3.11 3.12'.split():
+    for version in '3.9 3.10 3.11 3.12'.split():
         run_for_python(version, result, sys.argv[1:])


### PR DESCRIPTION
Python 3.7 and 3.8 are no longer supported.