### PR TITLE
Add accidentally removed wasSuccessful and control methods to StreamToExtendedDecorator

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,15 @@ testtools NEWS
 
 Changes and improvements to testtools_, grouped by release.
 
+2.8.1
+~~~~~
+
+Changes
+-------
+
+ * Re-add accidentally removed methods on StreamToExtendedDecorator.
+   (Jelmer Vernooĳ)
+
 2.8.0
 ~~~~~
 

--- a/testtools/testresult/real.py
+++ b/testtools/testresult/real.py
@@ -1879,6 +1879,36 @@ class StreamToExtendedDecorator(StreamResult):
         case = test_record.to_test_case()
         case.run(self.decorated)
 
+    def wasSuccessful(self):
+        """Return whether this result was successful.
+
+        Delegates to the decorated result object.
+        """
+        return self.decorated.wasSuccessful()
+
+    @property
+    def shouldStop(self):
+        """Return whether the test run should stop.
+
+        Delegates to the decorated result object.
+        """
+        return self.decorated.shouldStop
+
+    def stop(self):
+        """Indicate that the test run should stop.
+
+        Delegates to the decorated result object.
+        """
+        return self.decorated.stop()
+
+    @property
+    def testsRun(self):
+        """Return the number of tests run.
+
+        Delegates to the decorated result object.
+        """
+        return self.decorated.testsRun
+
 
 class StreamToQueue(StreamResult):
     """A StreamResult which enqueues events as a dict to a queue.Queue.


### PR DESCRIPTION
StreamToExtendedDecorator was missing key TestResult query methods (wasSuccessful, shouldStop, stop, testsRun), causing AttributeError when used with subunit2junitxml in version 1.4.5.