### PR TITLE
Fix packaging configuration warnings

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,4 +4,5 @@ include MANIFEST.in
 include NEWS
 include README.rst
 include .gitignore
+recursive-include doc *.rst *.py
 prune doc/_build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ version = {version!r}
 __version__ = {version_tuple!r}
 """
 
+[tool.hatch.build.targets.wheel]
+# testtools is not zip safe due to dynamic imports and resource loading
+only-include = ["testtools"]
+
 [tool.mypy]
 warn_redundant_casts = true
 warn_unused_configs = true


### PR DESCRIPTION
- Added explicit documentation files inclusion to MANIFEST.in to ensure all doc/*.rst and doc/*.py files are included in source distributions
- Added wheel build configuration to properly specify package contents with only-include directive, addressing the implicit zip_safe concerns
- The doc/_build prune directive is kept to exclude build artifacts

Fixes: https://bugs.launchpad.net/testtools/+bug/803845