### PR TITLE
Vendor LoggingFixture and make fixtures, testresources hard requirements for testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires-python = ">=3.10"
 Homepage = "https://github.com/testing-cabal/testtools"
 
 [project.optional-dependencies]
-test = ["testscenarios", "testresources"]
+test = ["fixtures", "testscenarios", "testresources"]
 twisted = ["Twisted", "fixtures"]
 dev = [
     "ruff==0.15.10",

--- a/tests/test_fixturesupport.py
+++ b/tests/test_fixturesupport.py
@@ -2,6 +2,8 @@
 
 import unittest
 
+import fixtures
+
 from testtools import (
     TestCase,
     content,
@@ -15,36 +17,25 @@ from testtools.testresult.doubles import (
     ExtendedTestResult,
 )
 
-try:
-    import fixtures
-except ImportError:
-    fixtures = None  # type: ignore
 
-if fixtures:
+class LoggingFixture(fixtures.Fixture):
+    def __init__(self, suffix: str = "", calls: list[str] | None = None) -> None:
+        super().__init__()
+        if calls is None:
+            calls = []
+        self.calls = calls
+        self.suffix = suffix
 
-    class LoggingFixture(fixtures.Fixture):
-        def __init__(self, suffix: str = "", calls: list[str] | None = None) -> None:
-            super().__init__()
-            if calls is None:
-                calls = []
-            self.calls = calls
-            self.suffix = suffix
+    def setUp(self) -> None:
+        super().setUp()
+        self.calls.append("setUp" + self.suffix)
+        self.addCleanup(self.calls.append, "cleanUp" + self.suffix)
 
-        def setUp(self) -> None:
-            super().setUp()
-            self.calls.append("setUp" + self.suffix)
-            self.addCleanup(self.calls.append, "cleanUp" + self.suffix)
-
-        def reset(self) -> None:
-            self.calls.append("reset" + self.suffix)
+    def reset(self) -> None:
+        self.calls.append("reset" + self.suffix)
 
 
 class TestFixtureSupport(TestCase):
-    def setUp(self):
-        super().setUp()
-        if fixtures is None or LoggingFixture is None:
-            self.skipTest("Need fixtures")
-
     def test_useFixture(self):
         fixture = LoggingFixture()
 

--- a/tests/test_fixturesupport.py
+++ b/tests/test_fixturesupport.py
@@ -20,10 +20,23 @@ try:
 except ImportError:
     fixtures = None  # type: ignore
 
-try:
-    from fixtures.tests.helpers import LoggingFixture
-except ImportError:
-    LoggingFixture = None
+if fixtures:
+
+    class LoggingFixture(fixtures.Fixture):
+        def __init__(self, suffix: str = "", calls: list[str] | None = None) -> None:
+            super().__init__()
+            if calls is None:
+                calls = []
+            self.calls = calls
+            self.suffix = suffix
+
+        def setUp(self) -> None:
+            super().setUp()
+            self.calls.append("setUp" + self.suffix)
+            self.addCleanup(self.calls.append, "cleanUp" + self.suffix)
+
+        def reset(self) -> None:
+            self.calls.append("reset" + self.suffix)
 
 
 class TestFixtureSupport(TestCase):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -9,6 +9,8 @@ import unittest
 from textwrap import dedent
 from unittest import TestSuite
 
+import fixtures
+
 import testtools
 from testtools import TestCase, run, skipUnless
 from testtools.matchers import (
@@ -17,29 +19,17 @@ from testtools.matchers import (
     MatchesRegex,
 )
 
-try:
-    import fixtures
-except ImportError:
-    fixtures = None  # type: ignore
 
-try:
-    import testresources
-except ImportError:
-    testresources = None
+class SampleTestFixture(fixtures.Fixture):
+    """Creates testtools.runexample temporarily."""
 
+    def __init__(self, broken=False):
+        """Create a SampleTestFixture.
 
-if fixtures:
-
-    class SampleTestFixture(fixtures.Fixture):
-        """Creates testtools.runexample temporarily."""
-
-        def __init__(self, broken=False):
-            """Create a SampleTestFixture.
-
-            :param broken: If True, the sample file will not be importable.
-            """
-            if not broken:
-                init_contents = b"""\
+        :param broken: If True, the sample file will not be importable.
+        """
+        if not broken:
+            init_contents = b"""\
 from testtools import TestCase
 
 class TestFoo(TestCase):
@@ -51,33 +41,31 @@ def test_suite():
     from unittest import TestLoader
     return TestLoader().loadTestsFromName(__name__)
 """
-            else:
-                init_contents = b"class not in\n"
-            self.package = fixtures.PythonPackage(
-                "runexample", [("__init__.py", init_contents)]
-            )
+        else:
+            init_contents = b"class not in\n"
+        self.package = fixtures.PythonPackage(
+            "runexample", [("__init__.py", init_contents)]
+        )
 
-        def setUp(self):
-            super().setUp()
-            self.useFixture(self.package)
-            testtools.__path__.append(self.package.base)
-            self.addCleanup(testtools.__path__.remove, self.package.base)
-            self.addCleanup(sys.modules.pop, "testtools.runexample", None)
+    def setUp(self):
+        super().setUp()
+        self.useFixture(self.package)
+        testtools.__path__.append(self.package.base)
+        self.addCleanup(testtools.__path__.remove, self.package.base)
+        self.addCleanup(sys.modules.pop, "testtools.runexample", None)
 
 
-if fixtures and testresources:
+class SampleResourcedFixture(fixtures.Fixture):
+    """Creates a test suite that uses testresources."""
 
-    class SampleResourcedFixture(fixtures.Fixture):
-        """Creates a test suite that uses testresources."""
-
-        def __init__(self):
-            super().__init__()
-            self.package = fixtures.PythonPackage(
-                "resourceexample",
-                [
-                    (
-                        "__init__.py",
-                        b"""
+    def __init__(self):
+        super().__init__()
+        self.package = fixtures.PythonPackage(
+            "resourceexample",
+            [
+                (
+                    "__init__.py",
+                    b"""
 from fixtures import Fixture
 from testresources import (
     FixtureResource,
@@ -109,30 +97,28 @@ def test_suite():
     from unittest import TestLoader
     return OptimisingTestSuite(TestLoader().loadTestsFromName(__name__))
 """,
-                    )
-                ],
-            )
+                )
+            ],
+        )
 
-        def setUp(self):
-            super().setUp()
-            self.useFixture(self.package)
-            self.addCleanup(testtools.__path__.remove, self.package.base)
-            testtools.__path__.append(self.package.base)
+    def setUp(self):
+        super().setUp()
+        self.useFixture(self.package)
+        self.addCleanup(testtools.__path__.remove, self.package.base)
+        testtools.__path__.append(self.package.base)
 
 
-if fixtures:
+class SampleLoadTestsPackage(fixtures.Fixture):
+    """Creates a test suite package using load_tests."""
 
-    class SampleLoadTestsPackage(fixtures.Fixture):
-        """Creates a test suite package using load_tests."""
-
-        def __init__(self):
-            super().__init__()
-            self.package = fixtures.PythonPackage(
-                "discoverexample",
-                [
-                    (
-                        "__init__.py",
-                        b"""
+    def __init__(self):
+        super().__init__()
+        self.package = fixtures.PythonPackage(
+            "discoverexample",
+            [
+                (
+                    "__init__.py",
+                    b"""
 from testtools import TestCase, clone_test_with_new_id
 
 class TestExample(TestCase):
@@ -143,22 +129,17 @@ def load_tests(loader, tests, pattern):
     tests.addTest(clone_test_with_new_id(tests._tests[1]._tests[0], "fred"))
     return tests
 """,
-                    )
-                ],
-            )
+                )
+            ],
+        )
 
-        def setUp(self):
-            super().setUp()
-            self.useFixture(self.package)
-            self.addCleanup(sys.path.remove, self.package.base)
+    def setUp(self):
+        super().setUp()
+        self.useFixture(self.package)
+        self.addCleanup(sys.path.remove, self.package.base)
 
 
 class TestRun(TestCase):
-    def setUp(self):
-        super().setUp()
-        if fixtures is None:
-            self.skipTest("Need fixtures")
-
     def test_run_custom_list(self):
         self.useFixture(SampleTestFixture())
         tests = []
@@ -347,8 +328,6 @@ testtools.runexample.missingtest
         )
 
     def test_load_list_preserves_custom_suites(self):
-        if testresources is None:
-            self.skipTest("Need testresources")
         self.useFixture(SampleResourcedFixture())
         # We load two tests, not loading one. Both share a resource, so we
         # should see just one resource setup occur.

--- a/tests/test_testresult.py
+++ b/tests/test_testresult.py
@@ -18,6 +18,8 @@ from queue import Queue
 from typing import Any
 from unittest import TestSuite
 
+import testresources
+
 from testtools import (
     CopyStreamResult,
     ExtendedToOriginalDecorator,
@@ -83,11 +85,6 @@ from .helpers import (
     an_exc_info,
     run_with_stack_hidden,
 )
-
-try:
-    import testresources
-except ImportError:
-    testresources = None
 
 
 def _utcfromtimestamp(t):
@@ -1477,11 +1474,6 @@ class TestExtendedToStreamDecorator(TestCase):
 
 
 class TestResourcedToStreamDecorator(TestCase):
-    def setUp(self):
-        super().setUp()
-        if testresources is None:
-            self.skipTest("Need testresources")
-
     def test_startMakeResource(self):
         log = LoggingStreamResult()
         result = ResourcedToStreamDecorator(log)

--- a/tests/test_testsuite.py
+++ b/tests/test_testsuite.py
@@ -6,6 +6,8 @@ import doctest
 import unittest
 from pprint import pformat
 
+from fixtures import FunctionFixture
+
 from testtools import (
     ConcurrentStreamTestSuite,
     ConcurrentTestSuite,
@@ -19,11 +21,6 @@ from testtools.testresult.doubles import StreamResult
 from testtools.testsuite import FixtureSuite, sorted_tests
 
 from .helpers import LoggingResult
-
-try:
-    from fixtures import FunctionFixture
-except ImportError:
-    FunctionFixture = None  # type: ignore
 
 
 class Sample(TestCase):
@@ -348,11 +345,6 @@ TypeError: ...run() takes ...1 ...argument...2...given...
 
 
 class TestFixtureSuite(TestCase):
-    def setUp(self):
-        super().setUp()
-        if FunctionFixture is None:
-            self.skipTest("Need fixtures")
-
     def test_fixture_suite(self):
         log: list[int | str] = []
 


### PR DESCRIPTION
Split out from https://github.com/testing-cabal/testtools/pull/593.

Note that we are not making these hard dependencies at runtime, only for the test suite (which is no longer packaged).
